### PR TITLE
Travel & Activity UX polish (Phase 1)

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -20,6 +20,8 @@
   /* Brand / Actions — Slack Aubergine */
   --color-primary: #4A154B;
   --color-primary-hover: #3D1040;
+  --color-primary-tint: #F5EEF8; /* aubergine wash for subtle fills */
+  --color-primary-ring: rgba(74, 21, 75, 0.12); /* focus/elevation ring */
 
   /* Status — Slack brand colors */
   --color-success: #2EB67D;
@@ -1452,6 +1454,11 @@ a:hover {
 /* ===== PeopleField Dropdown ===== */
 .people-field-dropdown {
   max-height: 320px;
+  /* Lift the picker clearly off the white form behind it: aubergine hairline
+     border, soft brand ring, and a stronger shadow so it reads as a distinct
+     surface rather than blending into the field. */
+  border: 1px solid var(--color-primary);
+  box-shadow: var(--card-shadow-hover), 0 0 0 3px var(--color-primary-ring);
 }
 
 .people-field-section {
@@ -1466,10 +1473,11 @@ a:hover {
 .people-field-section-header {
   font-size: var(--font-size-xs);
   font-weight: 700;
-  color: var(--color-text-secondary);
+  color: var(--color-primary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  padding: 0.375rem 0.75rem 0.25rem;
+  padding: 0.375rem 0.75rem 0.3rem;
+  background: var(--color-primary-tint);
 }
 
 .people-field-rings {
@@ -1725,6 +1733,76 @@ a:hover {
 
 .photo-lightbox-close:hover {
   background: rgba(255, 255, 255, 0.28);
+}
+
+/* ── Carousel arrows ── */
+.photo-lightbox-arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(255, 255, 255, 0.15);
+  border: none;
+  color: #fff;
+  font-size: 3rem;
+  line-height: 1;
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 150ms ease;
+  z-index: 10;
+  user-select: none;
+}
+.photo-lightbox-arrow:hover {
+  background: rgba(255, 255, 255, 0.30);
+}
+.photo-lightbox-arrow--prev { left: 1.25rem; }
+.photo-lightbox-arrow--next { right: 1.25rem; }
+
+/* ── Caption bar (attribution + counter) ── */
+.photo-lightbox-caption {
+  position: absolute;
+  bottom: 1.25rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(6px);
+  border-radius: 24px;
+  padding: 0.375rem 1rem;
+  white-space: nowrap;
+  max-width: calc(100vw - 2.5rem);
+}
+.photo-lightbox-attribution {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.photo-lightbox-attribution-name {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: #fff;
+}
+.photo-lightbox-counter {
+  font-size: var(--font-size-xs);
+  color: rgba(255, 255, 255, 0.75);
+  font-weight: 500;
+}
+
+/* ── Responsive: tuck arrows closer on small screens ── */
+@media (max-width: 575.98px) {
+  .photo-lightbox-arrow {
+    width: 40px;
+    height: 40px;
+    font-size: 2.25rem;
+  }
+  .photo-lightbox-arrow--prev { left: 0.5rem; }
+  .photo-lightbox-arrow--next { right: 0.5rem; }
 }
 
 /* ===== Memories Page (Snaps.js) ===== */

--- a/client/src/components/shared/CityAutocomplete.js
+++ b/client/src/components/shared/CityAutocomplete.js
@@ -11,13 +11,16 @@ const MAPBOX_TOKEN = process.env.REACT_APP_MAPBOX_TOKEN;
  *   { city, state, country, lat, lng }
  * where country is the ISO 2-letter code.
  */
-function CityAutocomplete({ value, onChange, onLocationSelect, id, placeholder = "e.g. Tokyo", disabled, countryCode }) {
+function CityAutocomplete({ value, onChange, onLocationSelect, id, placeholder = "e.g. Tokyo", disabled, countryCode, autoGeocode = false, hasCoords = false }) {
   const [query, setQuery] = useState(value || "");
   const [suggestions, setSuggestions] = useState([]);
   const [loading, setLoading] = useState(false);
   const [showDropdown, setShowDropdown] = useState(false);
   const debounceRef = useRef(null);
   const wrapperRef = useRef(null);
+  // Tracks the query we've already resolved to coordinates so a blur after an
+  // explicit pick (or a previous blur-geocode) doesn't fire a duplicate lookup.
+  const lastResolvedQuery = useRef(null);
 
   // Sync external value changes (e.g. when editing an existing item)
   useEffect(() => {
@@ -72,6 +75,7 @@ function CityAutocomplete({ value, onChange, onLocationSelect, id, placeholder =
     setQuery(cityName);
     setSuggestions([]);
     setShowDropdown(false);
+    lastResolvedQuery.current = cityName.trim().toLowerCase();
 
     onChange({ target: { name: "city", value: cityName } });
 
@@ -93,6 +97,27 @@ function CityAutocomplete({ value, onChange, onLocationSelect, id, placeholder =
         lat: lat ? String(lat) : "",
         lng: lng ? String(lng) : "",
       });
+    }
+  };
+
+  // When a location form needs map coordinates but the user typed a city
+  // without picking a suggestion, resolve the best match on blur so the entry
+  // still gets lat/lng (and therefore a map pin). No-op once coords exist.
+  const handleBlur = async () => {
+    if (!autoGeocode || hasCoords || !MAPBOX_TOKEN) return;
+    const q = query.trim();
+    if (q.length < 2) return;
+    if (lastResolvedQuery.current === q.toLowerCase()) return;
+    try {
+      const countryParam = countryCode ? `&country=${countryCode.toLowerCase()}` : "";
+      const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(q)}.json?types=place&limit=1${countryParam}&access_token=${MAPBOX_TOKEN}`;
+      const res = await fetch(url);
+      if (!res.ok) return;
+      const data = await res.json();
+      const best = (data.features || [])[0];
+      if (best) handleSelect(best);
+    } catch {
+      // silently ignore geocoding errors
     }
   };
 
@@ -118,6 +143,7 @@ function CityAutocomplete({ value, onChange, onLocationSelect, id, placeholder =
         value={query}
         onChange={handleInputChange}
         onFocus={() => suggestions.length > 0 && setShowDropdown(true)}
+        onBlur={handleBlur}
         placeholder={placeholder}
         disabled={disabled}
         autoComplete="off"

--- a/client/src/components/shared/EntryView.js
+++ b/client/src/components/shared/EntryView.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { Button } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
 import { isFieldVisible } from "../../helpers/operator";
+import { getAllSocialPhotos } from "../../helpers/socialContent";
 import { RING_META } from "../../helpers/ringMeta";
 import { renderFieldValue } from "../../helpers/renderFieldValue";
 import collaboratorService from "../../services/collaboratorService";
@@ -54,6 +55,17 @@ function EntryView({
   });
 
   const photos = [item.photo1, item.photo2, item.photo3].filter(Boolean);
+
+  // Full carousel set: owner photos + each collaborator's photos with attribution.
+  // Falls back to own photos when no social data is loaded yet.
+  const socialPhotos = getAllSocialPhotos(item);
+  const lightboxPhotos = socialPhotos.length > 0
+    ? socialPhotos.map(({ contribution, url }) => ({
+        url,
+        label: contribution.displayName,
+        avatarUrl: contribution.avatarUrl,
+      }))
+    : photos.map((url) => ({ url }));
   const companions = item.companions;
   const hasCompanions = Array.isArray(companions) && companions.length > 0;
   const hasCollaborators = collaborators.length > 0;
@@ -98,7 +110,7 @@ function EntryView({
       {/* ─── Photos ─── */}
       {photos.length > 0 && (
         <div style={{ marginBottom: "1.25rem" }}>
-          <PhotoGrid photos={photos} height={200} />
+          <PhotoGrid photos={photos} lightboxPhotos={lightboxPhotos} height={200} />
         </div>
       )}
 

--- a/client/src/components/shared/ItemForm.js
+++ b/client/src/components/shared/ItemForm.js
@@ -530,6 +530,8 @@ function ItemForm({
             id={fieldId}
             value={value}
             countryCode={formData.country || ""}
+            autoGeocode={field.autoGeocode}
+            hasCoords={!!(formData.lat && formData.lng)}
             onChange={(e) => handleInputChange(e, setFormData)}
             onLocationSelect={(location) => {
               setFormData((prev) => {

--- a/client/src/components/shared/LinkedTripPicker.js
+++ b/client/src/components/shared/LinkedTripPicker.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import { Form } from "react-bootstrap";
 import dataService from "../../services/dataService";
 import { codeToFlag, getCountryName } from "../../data/countries";
+import TripLink from "./TripLink";
 
 /**
  * LinkedTripPicker — "Part of a Trip?" toggle + searchable trip selector.
@@ -61,9 +62,11 @@ function LinkedTripPicker({
   if (readOnly) {
     if (!linkedTripTitle) return null;
     return (
-      <span style={{ fontSize: "var(--font-size-sm)", color: "var(--color-text-secondary)" }}>
-        ✈️ {linkedTripTitle}
-      </span>
+      <TripLink
+        tripId={linkedTripId}
+        title={linkedTripTitle}
+        style={{ fontSize: "var(--font-size-sm)" }}
+      />
     );
   }
 

--- a/client/src/components/shared/PhotoGrid.js
+++ b/client/src/components/shared/PhotoGrid.js
@@ -1,16 +1,55 @@
-import React, { useState } from "react";
+import React, { useState, useEffect, useRef } from "react";
+import ReactDOM from "react-dom";
+import Avatar from "./Avatar";
 
 /**
  * Renders 1–3 photo URLs in an equal-width horizontal strip.
- * Used in item cards, itinerary headers, and the Memories page.
+ * Clicking any thumbnail opens a full-screen carousel lightbox.
  *
- * @param {string[]} photos - Array of image URLs (up to 3)
- * @param {number} height - Height of each photo cell in px (default 160)
- * @param {string} className - Additional CSS class names
+ * Props:
+ *   photos          string[]                    Thumbnail URLs (up to 3, shown in grid)
+ *   lightboxPhotos  {url, label?, avatarUrl?}[] Full carousel set (own + shared).
+ *                                               Defaults to `photos` if not provided.
+ *   height          number                      Thumbnail strip height in px (default 160)
+ *   className       string
  */
-function PhotoGrid({ photos, height = 160, className = "" }) {
-  const [lightbox, setLightbox] = useState(null);
+function PhotoGrid({ photos, lightboxPhotos: lightboxPhotosProp, height = 160, className = "" }) {
+  const [lightboxIdx, setLightboxIdx] = useState(null);
+  const touchStartX = useRef(null);
+
   const validPhotos = (photos || []).filter(Boolean).slice(0, 3);
+
+  // Full carousel set — prefer explicit prop, fall back to own photos
+  const carouselPhotos =
+    lightboxPhotosProp?.length > 0
+      ? lightboxPhotosProp
+      : validPhotos.map((url) => ({ url }));
+
+  const isOpen = lightboxIdx !== null;
+  const current = isOpen ? carouselPhotos[lightboxIdx] : null;
+  const total = carouselPhotos.length;
+
+  const prev = () => setLightboxIdx((i) => (i - 1 + total) % total);
+  const next = () => setLightboxIdx((i) => (i + 1) % total);
+  const close = () => setLightboxIdx(null);
+
+  const openAt = (url) => {
+    const idx = carouselPhotos.findIndex((p) => p.url === url);
+    setLightboxIdx(idx >= 0 ? idx : 0);
+  };
+
+  // Keyboard: ← → Escape
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e) => {
+      if (e.key === "Escape") close();
+      else if (e.key === "ArrowLeft") prev();
+      else if (e.key === "ArrowRight") next();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, total]);
 
   if (validPhotos.length === 0) return null;
 
@@ -33,49 +72,94 @@ function PhotoGrid({ photos, height = 160, className = "" }) {
           <div
             key={i}
             style={colStyle}
-            onClick={() => setLightbox(url)}
+            onClick={() => openAt(url)}
             role="button"
             tabIndex={0}
             aria-label={`View photo ${i + 1}`}
-            onKeyDown={(e) => e.key === "Enter" && setLightbox(url)}
+            onKeyDown={(e) => e.key === "Enter" && openAt(url)}
           >
             <img
               src={url}
               alt={`Moment ${i + 1}`}
-              style={{
-                width: "100%",
-                height: "100%",
-                objectFit: "cover",
-                display: "block",
-              }}
+              style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
             />
           </div>
         ))}
       </div>
 
-      {/* Inline lightbox overlay */}
-      {lightbox && (
+      {/* Carousel lightbox — portalled to body to avoid Bootstrap Modal stacking-context flicker */}
+      {isOpen && ReactDOM.createPortal(
         <div
           className="photo-lightbox-overlay"
-          onClick={() => setLightbox(null)}
+          onClick={close}
           role="dialog"
           aria-modal="true"
           aria-label="Photo viewer"
+          onTouchStart={(e) => { touchStartX.current = e.touches[0].clientX; }}
+          onTouchEnd={(e) => {
+            if (touchStartX.current === null) return;
+            const dx = e.changedTouches[0].clientX - touchStartX.current;
+            touchStartX.current = null;
+            if (Math.abs(dx) < 50) return;
+            dx < 0 ? next() : prev();
+          }}
         >
-          <button
-            className="photo-lightbox-close"
-            onClick={() => setLightbox(null)}
-            aria-label="Close"
-          >
+          {/* Close */}
+          <button className="photo-lightbox-close" onClick={close} aria-label="Close">
             &times;
           </button>
+
+          {/* Prev arrow */}
+          {total > 1 && (
+            <button
+              className="photo-lightbox-arrow photo-lightbox-arrow--prev"
+              onClick={(e) => { e.stopPropagation(); prev(); }}
+              aria-label="Previous photo"
+            >
+              &#8249;
+            </button>
+          )}
+
+          {/* Image */}
           <img
-            src={lightbox}
+            src={current.url}
             alt="Expanded view"
             className="photo-lightbox-img"
             onClick={(e) => e.stopPropagation()}
           />
-        </div>
+
+          {/* Next arrow */}
+          {total > 1 && (
+            <button
+              className="photo-lightbox-arrow photo-lightbox-arrow--next"
+              onClick={(e) => { e.stopPropagation(); next(); }}
+              aria-label="Next photo"
+            >
+              &#8250;
+            </button>
+          )}
+
+          {/* Caption bar: attribution + counter */}
+          {(current.label || total > 1) && (
+            <div className="photo-lightbox-caption" onClick={(e) => e.stopPropagation()}>
+              {current.label && (
+                <div className="photo-lightbox-attribution">
+                  <Avatar
+                    displayName={current.label}
+                    avatarUrl={current.avatarUrl}
+                    size={22}
+                    style={{ flexShrink: 0 }}
+                  />
+                  <span className="photo-lightbox-attribution-name">{current.label}</span>
+                </div>
+              )}
+              {total > 1 && (
+                <span className="photo-lightbox-counter">{lightboxIdx + 1} / {total}</span>
+              )}
+            </div>
+          )}
+        </div>,
+        document.body
       )}
     </>
   );

--- a/client/src/components/shared/SourceFilterPills.js
+++ b/client/src/components/shared/SourceFilterPills.js
@@ -4,7 +4,7 @@ const SOURCE_OPTIONS = [
   { id: "all", label: "All", emoji: null },
   { id: "mine", label: "Mine", emoji: null },
   { id: "shared", label: "Shared", emoji: "\u{1F91D}" },
-  { id: "recommended", label: "Rec'd", emoji: "⭐" },
+  { id: "recommended", label: "Recommended", emoji: "⭐" },
 ];
 
 function SourceFilterPills({ value, onChange, avatarUrl, sharedCount, recommendedCount }) {

--- a/client/src/components/shared/TripLink.js
+++ b/client/src/components/shared/TripLink.js
@@ -1,0 +1,67 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+
+/**
+ * TripLink — renders a linked trip's name as a clickable affordance that deep
+ * links to the trip's detail on the Travel page (`/travel?view=<tripId>`).
+ *
+ * Used anywhere an activity (or other entry) references a parent trip — the
+ * compact card label and the read-only detail view — so the linking treatment
+ * is identical everywhere. Falls back to plain text when there's no tripId.
+ *
+ * Props:
+ *   tripId  — the linked trip's id (linkedTripId)
+ *   title   — the trip's display name (linkedTripTitle)
+ *   style   — optional style overrides merged onto the element
+ */
+function TripLink({ tripId, title, style }) {
+  const navigate = useNavigate();
+  if (!title) return null;
+
+  const label = (
+    <>
+      {"✈️"} {title}
+    </>
+  );
+
+  const baseStyle = {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "0.25rem",
+    fontSize: "var(--font-size-xs)",
+    ...style,
+  };
+
+  if (!tripId) {
+    return (
+      <span style={{ ...baseStyle, color: "var(--color-text-tertiary)" }}>
+        {label}
+      </span>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className="trip-link"
+      onClick={(e) => {
+        e.stopPropagation();
+        navigate(`/travel?view=${tripId}`);
+      }}
+      style={{
+        ...baseStyle,
+        background: "none",
+        border: "none",
+        padding: 0,
+        cursor: "pointer",
+        color: "var(--color-travel)",
+        fontWeight: 600,
+        textDecoration: "none",
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+export default TripLink;

--- a/client/src/features/activities/activitySchema.js
+++ b/client/src/features/activities/activitySchema.js
@@ -1,5 +1,5 @@
 import { baseSchema } from "../../helpers/common.schema";
-import { getStatusValues } from "../../helpers/statusLabels";
+import { getStatusField } from "../../helpers/statusLabels";
 import { getReflectionFields, getCompanionsField } from "../../helpers/reflection.schema";
 import { getLocationFields } from "../../helpers/location.schema";
 
@@ -32,15 +32,7 @@ export const ACTIVITY_TYPE_OPTIONS = Object.entries(ACTIVITY_TYPES).flatMap(
 );
 
 const activityFields = [
-  {
-    name: "status",
-    label: "Status",
-    type: "select",
-    options: getStatusValues("activities"),
-    required: true,
-    section: "Main",
-    order: 0,
-  },
+  getStatusField("activities"),
   {
     name: "activityType",
     label: "Activity",

--- a/client/src/features/activities/components/ActivityList.js
+++ b/client/src/features/activities/components/ActivityList.js
@@ -1,4 +1,5 @@
 import React, { useEffect } from "react";
+import { isMineOnly, isSharedSource } from "../../../helpers/operator";
 import { Button } from "react-bootstrap";
 import { useLocation } from "react-router-dom";
 import ActivityForm from "./ActivityForm";
@@ -7,6 +8,7 @@ import FormPanel from "../../../components/shared/FormPanel";
 import SaveToast from "../../../components/shared/SaveToast";
 import SnapCaptureModal from "../../../components/shared/SnapCaptureModal";
 import EntryDetailPanel from "../../../components/shared/EntryDetailPanel";
+import TripLink from "../../../components/shared/TripLink";
 import CategoryListHeader from "../../../components/shared/CategoryListHeader";
 import { RATING_GROUP } from "../../../components/shared/GroupedDropdownFilter";
 import activitySchema, { ACTIVITY_TYPES } from "../activitySchema";
@@ -46,9 +48,9 @@ function ActivityList() {
   const activityStatuses = getStatusFilterOptions("activities");
   const statusFiltered = filterByStatus(activities, filterStatus);
   const sourceFiltered = sourceFilter === "mine"
-    ? statusFiltered.filter((i) => !i._isShared)
+    ? statusFiltered.filter(isMineOnly)
     : sourceFilter === "shared"
-    ? statusFiltered.filter((i) => i._isShared)
+    ? statusFiltered.filter(isSharedSource)
     : sourceFilter === "recommended"
     ? statusFiltered.filter((i) => i._isRecommended)
     : statusFiltered;
@@ -67,7 +69,7 @@ function ActivityList() {
     }
     return sourceFiltered.filter((i) => i.activityType === activityTypeFilter);
   }, [sourceFiltered, activityTypeFilter]);
-  const sharedCount = activities.filter((i) => i._isShared).length;
+  const sharedCount = activities.filter(isSharedSource).length;
   const recommendedCount = activities.filter((i) => i._isRecommended).length;
 
   const done = activities.filter((i) => i.status === "done");
@@ -144,15 +146,8 @@ function ActivityList() {
         onViewDetail={setViewDetailItem}
         renderCompactExtra={(item) =>
           item.linkedTripTitle ? (
-            <div style={{
-              display: "inline-flex",
-              alignItems: "center",
-              gap: "0.25rem",
-              marginTop: "0.2rem",
-              fontSize: "var(--font-size-xs)",
-              color: "var(--color-text-tertiary)",
-            }}>
-              {"\u2708\uFE0F"} {item.linkedTripTitle}
+            <div style={{ marginTop: "0.2rem" }}>
+              <TripLink tripId={item.linkedTripId} title={item.linkedTripTitle} />
             </div>
           ) : null
         }
@@ -174,7 +169,7 @@ function ActivityList() {
       <SaveToast
         show={showToast}
         onClose={() => setShowToast(false)}
-        message="Activity logged \u2705"
+        message={"Activity logged \u2705"}
       />
 
       <SnapCaptureModal

--- a/client/src/features/cars/carSchema.js
+++ b/client/src/features/cars/carSchema.js
@@ -1,17 +1,9 @@
 import { baseSchema } from "../../helpers/common.schema";
-import { getStatusValues } from "../../helpers/statusLabels";
+import { getStatusField } from "../../helpers/statusLabels";
 import { getReflectionFields } from "../../helpers/reflection.schema";
 
 const carSchema = [
-  {
-    name: "status",
-    label: "Status",
-    type: "select",
-    options: getStatusValues("cars"),
-    required: true,
-    section: "Main",
-    order: 0,
-  },
+  getStatusField("cars"),
 
   {
     name: "vin",

--- a/client/src/features/cars/components/CarList.js
+++ b/client/src/features/cars/components/CarList.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { isMineOnly, isSharedSource } from "../../../helpers/operator";
 import { Button } from "react-bootstrap";
 import CarForm from "../../../features/cars/components/CarForm";
 import ItemCardList from "../../../components/shared/ItemCardList";
@@ -37,9 +38,9 @@ function CarList() {
   const carStatuses = getStatusFilterOptions("cars");
   const statusFiltered = filterByStatus(cars, filterStatus);
   const sourceFiltered = sourceFilter === "mine"
-    ? statusFiltered.filter((i) => !i._isShared)
+    ? statusFiltered.filter(isMineOnly)
     : sourceFilter === "shared"
-    ? statusFiltered.filter((i) => i._isShared)
+    ? statusFiltered.filter(isSharedSource)
     : sourceFilter === "recommended"
     ? statusFiltered.filter((i) => i._isRecommended)
     : statusFiltered;
@@ -60,7 +61,7 @@ function CarList() {
     return sourceFiltered;
   }, [sourceFiltered, carFilter]);
 
-  const sharedCount = cars.filter((i) => i._isShared).length;
+  const sharedCount = cars.filter(isSharedSource).length;
   const recommendedCount = cars.filter((i) => i._isRecommended).length;
   const sectionTitle = `Cars - ${getStatusLabel("cars", filterStatus)}`;
 
@@ -135,7 +136,7 @@ function CarList() {
       <SaveToast
         show={showToast}
         onClose={() => setShowToast(false)}
-        message="Car saved \u2705"
+        message={"Car saved \u2705"}
       />
 
       <SnapCaptureModal

--- a/client/src/features/cellar/cellarSchema.js
+++ b/client/src/features/cellar/cellarSchema.js
@@ -1,5 +1,5 @@
 import { baseSchema } from "../../helpers/common.schema";
-import { getStatusValues } from "../../helpers/statusLabels";
+import { getStatusField } from "../../helpers/statusLabels";
 import { getReflectionFields, getCompanionsField } from "../../helpers/reflection.schema";
 
 export const WINE_TYPES = ["Red", "White", "Rosé", "Sparkling", "Dessert", "Fortified", "Orange"];
@@ -29,16 +29,7 @@ const cellarSchema = [
   },
 
   // ── Main ────────────────────────────────────────────────────────────────────
-  {
-    name: "status",
-    label: "Status",
-    type: "select",
-    options: getStatusValues("cellar"),
-    optionLabels: { tried: "Enjoyed", cellar: "In Cellar", wishlist: "Wishlist" },
-    required: true,
-    section: "Main",
-    order: 0,
-  },
+  getStatusField("cellar"),
 
   // ── Wine-specific fields ───────────────────────────────────────────────────
   {

--- a/client/src/features/cellar/components/CellarList.js
+++ b/client/src/features/cellar/components/CellarList.js
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from "react";
+import { isMineOnly, isSharedSource } from "../../../helpers/operator";
 import { Button } from "react-bootstrap";
 import CellarForm from "./CellarForm";
 import ItemCardList from "../../../components/shared/ItemCardList";
@@ -113,8 +114,8 @@ function CellarList() {
 
   const filteredItems = useMemo(() => {
     let items = statusFiltered;
-    if (sourceFilter === "mine") items = items.filter((i) => !i._isShared);
-    else if (sourceFilter === "shared") items = items.filter((i) => i._isShared);
+    if (sourceFilter === "mine") items = items.filter(isMineOnly);
+    else if (sourceFilter === "shared") items = items.filter(isSharedSource);
     else if (sourceFilter === "recommended") items = items.filter((i) => i._isRecommended);
 
     if (activeTab === "wine") items = items.filter((i) => (i.subType || "wine") === "wine");
@@ -184,7 +185,7 @@ function CellarList() {
         sourceFilter={sourceFilter}
         onSourceChange={setSourceFilter}
         avatarUrl={profile?.avatar_url}
-        sharedCount={cellarItems.filter((i) => i._isShared).length}
+        sharedCount={cellarItems.filter(isSharedSource).length}
         recommendedCount={cellarItems.filter((i) => i._isRecommended).length}
       />
 

--- a/client/src/features/events/components/EventList.js
+++ b/client/src/features/events/components/EventList.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo } from "react";
+import { isMineOnly, isSharedSource } from "../../../helpers/operator";
 import { Button } from "react-bootstrap";
 import eventSchema, { EVENT_TYPES } from "../eventSchema";
 import EventForm from "./EventForm";
@@ -97,9 +98,9 @@ function EventList() {
   const eventStatuses = getStatusFilterOptions("events");
   const statusFiltered = filterByStatus(events, filterStatus);
   const sourceFiltered = sourceFilter === "mine"
-    ? statusFiltered.filter((i) => !i._isShared)
+    ? statusFiltered.filter(isMineOnly)
     : sourceFilter === "shared"
-    ? statusFiltered.filter((i) => i._isShared)
+    ? statusFiltered.filter(isSharedSource)
     : sourceFilter === "recommended"
     ? statusFiltered.filter((i) => i._isRecommended)
     : statusFiltered;
@@ -120,7 +121,7 @@ function EventList() {
     return sourceFiltered.filter((i) => i.eventType === filterType);
   }, [sourceFiltered, filterType]);
 
-  const sharedCount = events.filter((i) => i._isShared).length;
+  const sharedCount = events.filter(isSharedSource).length;
   const recommendedCount = events.filter((i) => i._isRecommended).length;
   const sectionTitle = `Events - ${getStatusLabel("events", filterStatus)}`;
 

--- a/client/src/features/events/eventSchema.js
+++ b/client/src/features/events/eventSchema.js
@@ -1,5 +1,5 @@
 import { baseSchema } from "../../helpers/common.schema";
-import { getStatusValues } from "../../helpers/statusLabels";
+import { getStatusField } from "../../helpers/statusLabels";
 import { getReflectionFields, getCompanionsField } from "../../helpers/reflection.schema";
 import { getLocationFields } from "../../helpers/location.schema";
 
@@ -13,15 +13,7 @@ export const EVENT_TYPES = [
 ];
 
 const eventSchema = [
-  {
-    name: "status",
-    label: "Status",
-    type: "select",
-    options: getStatusValues("events"),
-    required: true,
-    section: "Main",
-    order: 0,
-  },
+  getStatusField("events"),
   {
     name: "eventType",
     label: "Event Type",

--- a/client/src/features/homes/components/HomeList.js
+++ b/client/src/features/homes/components/HomeList.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { isMineOnly, isSharedSource } from "../../../helpers/operator";
 import { Button } from "react-bootstrap";
 import HomeForm from "../../../features/homes/components/HomeForm";
 import ItemCardList from "../../../components/shared/ItemCardList";
@@ -37,9 +38,9 @@ function HomeList() {
   const homeStatuses = getStatusFilterOptions("homes");
   const statusFiltered = filterByStatus(homes, filterStatus);
   const sourceFiltered = sourceFilter === "mine"
-    ? statusFiltered.filter((i) => !i._isShared)
+    ? statusFiltered.filter(isMineOnly)
     : sourceFilter === "shared"
-    ? statusFiltered.filter((i) => i._isShared)
+    ? statusFiltered.filter(isSharedSource)
     : sourceFilter === "recommended"
     ? statusFiltered.filter((i) => i._isRecommended)
     : statusFiltered;
@@ -60,7 +61,7 @@ function HomeList() {
     return sourceFiltered;
   }, [sourceFiltered, homeFilter]);
 
-  const sharedCount = homes.filter((i) => i._isShared).length;
+  const sharedCount = homes.filter(isSharedSource).length;
   const recommendedCount = homes.filter((i) => i._isRecommended).length;
   const sectionTitle = `Homes - ${getStatusLabel("homes", filterStatus)}`;
 
@@ -135,7 +136,7 @@ function HomeList() {
       <SaveToast
         show={showToast}
         onClose={() => setShowToast(false)}
-        message="Home saved \u2705"
+        message={"Home saved \u2705"}
       />
 
       <SnapCaptureModal

--- a/client/src/features/homes/homeSchema.js
+++ b/client/src/features/homes/homeSchema.js
@@ -1,18 +1,10 @@
 import { baseSchema } from "../../helpers/common.schema";
 import { locationSchema } from "../../helpers/location.schema";
-import { getStatusValues } from "../../helpers/statusLabels";
+import { getStatusField } from "../../helpers/statusLabels";
 import { getReflectionFields } from "../../helpers/reflection.schema";
 
 const homeSchema = [
-  {
-    name: "status",
-    label: "Status",
-    type: "select",
-    options: getStatusValues("homes"),
-    required: true,
-    section: "Main",
-    order: 0,
-  },
+  getStatusField("homes"),
 
   {
     name: "type",

--- a/client/src/features/kids/components/KidsList.js
+++ b/client/src/features/kids/components/KidsList.js
@@ -1,4 +1,5 @@
 import React, { useMemo } from "react";
+import { isMineOnly, isSharedSource } from "../../../helpers/operator";
 import { Button } from "react-bootstrap";
 import KidsForm from "./KidsForm";
 import ItemCardList from "../../../components/shared/ItemCardList";
@@ -188,9 +189,9 @@ function KidsList() {
   const statusFiltered = filterByStatus(milestones, filterStatus);
 
   const sourceFiltered = sourceFilter === "mine"
-    ? statusFiltered.filter((i) => !i._isShared)
+    ? statusFiltered.filter(isMineOnly)
     : sourceFilter === "shared"
-    ? statusFiltered.filter((i) => i._isShared)
+    ? statusFiltered.filter(isSharedSource)
     : sourceFilter === "recommended"
     ? statusFiltered.filter((i) => i._isRecommended)
     : statusFiltered;
@@ -213,7 +214,7 @@ function KidsList() {
     return items;
   }, [sourceFiltered, milestoneTypeFilter, childFilter, ratingFilter]);
 
-  const sharedCount = milestones.filter((i) => i._isShared).length;
+  const sharedCount = milestones.filter(isSharedSource).length;
   const recommendedCount = milestones.filter((i) => i._isRecommended).length;
 
   const groupedByYear = useMemo(() => {

--- a/client/src/features/kids/kidsSchema.js
+++ b/client/src/features/kids/kidsSchema.js
@@ -1,4 +1,4 @@
-import { getStatusValues } from "../../helpers/statusLabels";
+import { getStatusField } from "../../helpers/statusLabels";
 import { getReflectionFields, getCompanionsField } from "../../helpers/reflection.schema";
 import { baseSchema } from "../../helpers/common.schema";
 
@@ -13,15 +13,7 @@ export const KIDS_EVENT_TYPES = [
 ];
 
 const kidsSchema = [
-  {
-    name: "status",
-    label: "Status",
-    type: "select",
-    options: getStatusValues("kids"),
-    required: true,
-    section: "Main",
-    order: 0,
-  },
+  getStatusField("kids"),
   {
     name: "milestoneType",
     label: "Milestone Type",

--- a/client/src/features/movies/components/MovieList.js
+++ b/client/src/features/movies/components/MovieList.js
@@ -1,4 +1,5 @@
 import React, { useState, useMemo, useCallback, useEffect, useRef } from "react";
+import { isMineOnly, isSharedSource } from "../../../helpers/operator";
 import { Button, Spinner } from "react-bootstrap";
 import movieSchema from "../movieSchema";
 import MovieForm from "./MovieForm";
@@ -213,9 +214,9 @@ function MovieList() {
 
   const statusFiltered = filterByStatus(movies, filterStatus);
   const sourceFiltered = sourceFilter === "mine"
-    ? statusFiltered.filter((i) => !i._isShared)
+    ? statusFiltered.filter(isMineOnly)
     : sourceFilter === "shared"
-    ? statusFiltered.filter((i) => i._isShared)
+    ? statusFiltered.filter(isSharedSource)
     : sourceFilter === "recommended"
     ? statusFiltered.filter((i) => i._isRecommended)
     : statusFiltered;
@@ -276,7 +277,7 @@ function MovieList() {
         sourceFilter={sourceFilter}
         onSourceChange={setSourceFilter}
         avatarUrl={profile?.avatar_url}
-        sharedCount={movies.filter((i) => i._isShared).length}
+        sharedCount={movies.filter(isSharedSource).length}
         recommendedCount={movies.filter((i) => i._isRecommended).length}
       />
 

--- a/client/src/features/movies/movieSchema.js
+++ b/client/src/features/movies/movieSchema.js
@@ -1,17 +1,9 @@
 import { baseSchema } from "../../helpers/common.schema";
-import { getStatusValues } from "../../helpers/statusLabels";
+import { getStatusField } from "../../helpers/statusLabels";
 import { getReflectionFields, getCompanionsField } from "../../helpers/reflection.schema";
 
 const movieSchema = [
-  {
-    name: "status",
-    label: "Status",
-    type: "select",
-    options: getStatusValues("movies"),
-    required: true,
-    section: "Main",
-    order: 0,
-  },
+  getStatusField("movies"),
   {
     name: "title",
     label: "Title",

--- a/client/src/features/travel/components/TravelList.js
+++ b/client/src/features/travel/components/TravelList.js
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect, useMemo } from "react";
 import { Button, Modal, Form } from "react-bootstrap";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import TravelForm from "../../../features/travel/components/TravelForm";
 import ItemCardList from "../../../components/shared/ItemCardList";
 import FormPanel from "../../../components/shared/FormPanel";
@@ -19,7 +19,7 @@ import { useAppData } from "../../../contexts/AppDataContext";
 import { codeToFlag, getCountryName } from "../../../data/countries";
 import dataService from "../../../services/dataService";
 import { computeTravelStats } from "../../../services/travelStats";
-import { getTripPhotos } from "../../../helpers/operator";
+import { getTripPhotos, getItemPhotos, isMineOnly, isSharedSource } from "../../../helpers/operator";
 import {
   getStatusFilterOptions,
   filterByStatus,
@@ -272,6 +272,7 @@ function LinkedActivityRow({ activity }) {
 
 
   const snapshots = [activity.snapshot1, activity.snapshot2, activity.snapshot3].filter(Boolean);
+  const photos = getItemPhotos(activity);
 
   return (
     <div style={{ borderBottom: "1px solid var(--color-border)", paddingBottom: "0.35rem", marginBottom: "0.35rem" }}>
@@ -335,6 +336,11 @@ function LinkedActivityRow({ activity }) {
               ✨ "{snap}"
             </div>
           ))}
+          {photos.length > 0 && (
+            <div style={{ marginTop: "0.3rem", marginBottom: "0.35rem" }}>
+              <PhotoGrid photos={photos} height={80} />
+            </div>
+          )}
           {activity.notes && (
             <div style={{ fontSize: "var(--font-size-xs)", color: "var(--color-text-secondary)", marginBottom: "0.2rem" }}>
               {activity.notes}
@@ -455,6 +461,7 @@ const VIEW_TABS = [
 
 function TravelList() {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { profile } = useAppData();
   const [activeView, setActiveView] = useState("list");
   const [selectedCountry, setSelectedCountry] = useState(null);
@@ -486,16 +493,30 @@ function TravelList() {
     dataService.getItems("activities").then(setLinkedActivities);
   }, []);
 
+  // Deep link: /travel?view=<tripId> opens that trip's detail (e.g. when an
+  // activity links back to its trip). Handled once the trips have loaded.
+  const viewParamHandled = useRef(false);
+  useEffect(() => {
+    if (loading || viewParamHandled.current) return;
+    const viewId = searchParams.get("view");
+    if (viewId) {
+      const trip = travels.find((t) => t.id === viewId);
+      if (trip) setViewDetailItem(trip);
+      viewParamHandled.current = true;
+      setSearchParams({}, { replace: true });
+    }
+  }, [loading, travels, searchParams, setSearchParams, setViewDetailItem]);
+
   const travelStatuses = getStatusFilterOptions("travel");
   const statusFiltered = filterByStatus(travels, filterStatus);
   const filteredTravels = sourceFilter === "mine"
-    ? statusFiltered.filter((i) => !i._isShared)
+    ? statusFiltered.filter(isMineOnly)
     : sourceFilter === "shared"
-    ? statusFiltered.filter((i) => i._isShared)
+    ? statusFiltered.filter(isSharedSource)
     : sourceFilter === "recommended"
     ? statusFiltered.filter((i) => i._isRecommended)
     : statusFiltered;
-  const sharedCount = travels.filter((i) => i._isShared).length;
+  const sharedCount = travels.filter(isSharedSource).length;
   const recommendedCount = travels.filter((i) => i._isRecommended).length;
   const sectionTitle = `Travel - ${getStatusLabel("travel", filterStatus)}`;
 

--- a/client/src/features/travel/travelSchema.js
+++ b/client/src/features/travel/travelSchema.js
@@ -1,18 +1,10 @@
 import { baseSchema } from "../../helpers/common.schema";
-import { getStatusValues } from "../../helpers/statusLabels";
+import { getStatusField } from "../../helpers/statusLabels";
 import { getReflectionFields, getCompanionsField } from "../../helpers/reflection.schema";
 import { getLocationFields } from "../../helpers/location.schema";
 
 const travelFields = [
-  {
-    name: "status",
-    label: "Status",
-    type: "select",
-    options: getStatusValues("travel"),
-    required: true,
-    section: "Main",
-    order: 0,
-  },
+  getStatusField("travel"),
   {
     name: "title",
     label: "Trip Name",

--- a/client/src/helpers/location.schema.js
+++ b/client/src/helpers/location.schema.js
@@ -8,6 +8,8 @@ export function getLocationFields({ section = "Where", startOrder = 25 } = {}) {
       type: "city-autocomplete",
       optional: true,
       placeholder: "e.g. Austin",
+      // Resolve coordinates on blur so a typed city still drops a map pin.
+      autoGeocode: true,
       section,
       order: startOrder,
     },

--- a/client/src/helpers/operator.js
+++ b/client/src/helpers/operator.js
@@ -87,6 +87,17 @@ export const getItemPhotos = (item) =>
   [item.photo1, item.photo2, item.photo3].filter(Boolean);
 
 /**
+ * Source-filter classification used by every category's "All | Mine | Shared"
+ * pills. An item belongs to "Shared" if it was either received from someone else
+ * (_isShared) or the owner has shared it outward with a collaborator, pending or
+ * accepted (_hasOutgoingShares). "Mine" is the complement: owned and unshared.
+ */
+export const isSharedSource = (item) =>
+  !!(item._isShared || item._hasOutgoingShares);
+
+export const isMineOnly = (item) => !isSharedSource(item);
+
+/**
  * Returns the owner's photos and each companion's overlay photos separately.
  * @param {object} item - The entry item
  * @param {object[]} overlays - personalOverlay records for this entry

--- a/client/src/helpers/operator.source.test.js
+++ b/client/src/helpers/operator.source.test.js
@@ -1,0 +1,33 @@
+import { isMineOnly, isSharedSource } from "./operator";
+
+describe("source-filter classification (#4)", () => {
+  test("a plain owned item is Mine, not Shared", () => {
+    const item = { id: "1" };
+    expect(isMineOnly(item)).toBe(true);
+    expect(isSharedSource(item)).toBe(false);
+  });
+
+  test("an item received from someone else is Shared", () => {
+    const item = { id: "1", _isShared: true };
+    expect(isSharedSource(item)).toBe(true);
+    expect(isMineOnly(item)).toBe(false);
+  });
+
+  test("an owned item shared outward (even pending) is Shared, not Mine", () => {
+    const item = { id: "1", _hasOutgoingShares: true };
+    expect(isSharedSource(item)).toBe(true);
+    expect(isMineOnly(item)).toBe(false);
+  });
+
+  test("isMineOnly and isSharedSource are exact complements", () => {
+    const cases = [
+      {},
+      { _isShared: true },
+      { _hasOutgoingShares: true },
+      { _isShared: true, _hasOutgoingShares: true },
+    ];
+    cases.forEach((item) => {
+      expect(isMineOnly(item)).toBe(!isSharedSource(item));
+    });
+  });
+});

--- a/client/src/helpers/statusLabels.js
+++ b/client/src/helpers/statusLabels.js
@@ -61,3 +61,32 @@ export const getStatusLabel = (category, status) => {
   if (status === "all") return "All";
   return statusLabels[category]?.[status] || status;
 };
+
+/**
+ * Helper: Returns the full value→label map for a category
+ * (e.g. { done: "Accomplished", wishlist: "Wishlist" }).
+ * This is the same map StatusBadge, StatusToggle, and the source filters use,
+ * so wiring it into a form's <select> guarantees the dropdown labels match
+ * everywhere else.
+ */
+export const getStatusOptionLabels = (category) => {
+  return { ...(statusLabels[category] || {}) };
+};
+
+/**
+ * Helper: Schema factory for the standard "Status" select field.
+ * Pulls both the option values and their display labels from this single
+ * source of truth so the dropdown can never drift from the badges/filters.
+ * Pass `overrides` to tweak per-schema details (section, order, etc.).
+ */
+export const getStatusField = (category, overrides = {}) => ({
+  name: "status",
+  label: "Status",
+  type: "select",
+  options: getStatusValues(category),
+  optionLabels: getStatusOptionLabels(category),
+  required: true,
+  section: "Main",
+  order: 0,
+  ...overrides,
+});

--- a/client/src/helpers/statusLabels.test.js
+++ b/client/src/helpers/statusLabels.test.js
@@ -1,0 +1,44 @@
+import {
+  getStatusValues,
+  getStatusLabel,
+  getStatusOptionLabels,
+  getStatusField,
+} from "./statusLabels";
+
+describe("statusLabels — single source of truth", () => {
+  test("getStatusOptionLabels returns the value→label map for a category", () => {
+    expect(getStatusOptionLabels("activities")).toEqual({
+      done: "Accomplished",
+      wishlist: "Wishlist",
+    });
+  });
+
+  test("getStatusOptionLabels returns a copy (not the internal object)", () => {
+    const a = getStatusOptionLabels("activities");
+    a.done = "Mutated";
+    expect(getStatusOptionLabels("activities").done).toBe("Accomplished");
+  });
+
+  test("getStatusOptionLabels is empty for an unknown category", () => {
+    expect(getStatusOptionLabels("nope")).toEqual({});
+  });
+
+  test("getStatusField wires options + optionLabels from the same source", () => {
+    const field = getStatusField("activities");
+    expect(field.name).toBe("status");
+    expect(field.type).toBe("select");
+    expect(field.options).toEqual(getStatusValues("activities"));
+    // The dropdown labels must match what badges/filters render.
+    field.options.forEach((value) => {
+      expect(field.optionLabels[value]).toBe(getStatusLabel("activities", value));
+    });
+    // Regression for #3: "done" must read "Accomplished", never "Done".
+    expect(field.optionLabels.done).toBe("Accomplished");
+  });
+
+  test("getStatusField applies overrides", () => {
+    const field = getStatusField("travel", { section: "Other", order: 5 });
+    expect(field.section).toBe("Other");
+    expect(field.order).toBe(5);
+  });
+});

--- a/client/src/services/dataService.js
+++ b/client/src/services/dataService.js
@@ -361,12 +361,33 @@ const dataService = {
   /**
    * Get items for a category merged with accepted shared entries from collaborators.
    * Shared entries get _isShared=true and _sharedBy set to the owner's user ID.
+   *
+   * Own items that the user has shared with at least one collaborator (any status,
+   * including pending invites) get _hasOutgoingShares=true so the source filter can
+   * surface them under "Shared" rather than "Mine". _isShared is intentionally left
+   * untouched on own items — it gates the save effect in useCategory.
    */
   async getItemsWithShared(category) {
-    const ownItems = await dataService.getItems(category);
+    let ownItems = await dataService.getItems(category);
 
     try {
       const userId = await getCurrentUserId();
+
+      // Outgoing shares: entries this user owns and has shared with anyone.
+      const { data: outgoing } = await supabase
+        .from("collaborators")
+        .select("entry_id")
+        .eq("owner_id", userId)
+        .eq("entry_category", category);
+
+      if (outgoing?.length) {
+        const sharedEntryIds = new Set(outgoing.map((c) => c.entry_id));
+        ownItems = ownItems.map((item) =>
+          sharedEntryIds.has(item.id) ? { ...item, _hasOutgoingShares: true } : item
+        );
+      }
+
+      // Incoming shares: accepted entries owned by someone else.
       const { data: collabs } = await supabase
         .from("collaborators")
         .select("entry_id, owner_id")


### PR DESCRIPTION
Phase 1 of the Travel/Activity UX polish — safe fixes + the Mine/Shared filter bug. Shippable independently of Phase 2.

## Items
- **#9 Toast emoji** — `message="…✅"` was a JSX *attribute* (escapes not interpreted) in Activity/Home/Car lists; wrapped in `{…}` so it renders ✅.
- **#3 Status labels** — new `getStatusField()`/`getStatusOptionLabels()` factory drives the form `<select>` from the same map as badges/filters; all 8 schemas use it. Activity status reads **Accomplished**, not "Done".
- **#5 Trip city / map pin** — `CityAutocomplete` auto-geocodes a typed city on blur (opt-in via location schema) so a trip drops a pin even without picking a Mapbox suggestion.
- **#1 Trip ↔ Activity links** — reusable `TripLink` on the activity card + read-only detail, deep-linking to `/travel?view=<tripId>` which `TravelList` opens as the trip detail.
- **#2 Inline photos** — activity photos now render under "Activities on this trip" (PhotoGrid); no need to "Open in Activities".
- **#4 Mine/Shared filter** — `getItemsWithShared` flags owner-shared entries (incl. pending) `_hasOutgoingShares`; new `isMineOnly`/`isSharedSource` helpers applied across all lists. `_isShared` and the save gate are untouched. "Rec'd" → **Recommended**.
- **#8 Dropdown contrast** — "My People" picker gets an aubergine border + brand ring + tinted section headers (token-based).

## Verification
- `npx react-scripts build` — compiles clean.
- `react-scripts test` — full suite green (9 new tests for status-label and source-classification helpers).
- Interactive/data-gated flows need a local `.env` (Supabase/Mapbox) + seeded data; not exercisable in CI sandbox.

## Note
Bundles pre-existing uncommitted work already in the tree (PhotoGrid portal lightbox, EntryView social-photo carousel, related App.css) that predates this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)