### PR TITLE
Visibility model: individuals + Everyone, linked to collaborate (Phase 2)

### DIFF
--- a/client/src/components/shared/EntryDetailPanel.js
+++ b/client/src/components/shared/EntryDetailPanel.js
@@ -32,6 +32,11 @@ function EntryDetailPanel({ item, category, schema, onClose, onSave, onDelete, r
         setFormData((prev) => ({
           ...prev,
           shareWithCompanionIds: sharedContactIds,
+          // collaborate ⟹ visible: surface existing collaborators under
+          // "Who can see this" even on entries saved before that field existed.
+          visibilityContacts: Array.from(
+            new Set([...(prev.visibilityContacts || []), ...sharedContactIds])
+          ),
           _collaboratorStatuses: collaboratorStatuses,
         }));
       } catch {

--- a/client/src/components/shared/ItemForm.js
+++ b/client/src/components/shared/ItemForm.js
@@ -10,6 +10,7 @@ import CountryDropdown from "./CountryDropdown";
 import CityAutocomplete from "./CityAutocomplete";
 import PeopleField from "./PeopleField";
 import ShareWithCompanionsToggle from "./ShareWithCompanionsToggle";
+import { applyCollaborateChange } from "../../helpers/visibilitySharing";
 import LinkedTripPicker from "./LinkedTripPicker";
 import PhotoUploadField from "./PhotoUploadField";
 import { getCountryContinent } from "../../data/countries";
@@ -759,10 +760,7 @@ function ItemForm({
                         value={formData.shareWithCompanionIds || []}
                         statuses={formData._collaboratorStatuses}
                         onChange={(ids) =>
-                          setFormData((prev) => ({
-                            ...prev,
-                            shareWithCompanionIds: ids,
-                          }))
+                          setFormData((prev) => applyCollaborateChange(prev, ids))
                         }
                       />
                     </Col>

--- a/client/src/components/shared/PeopleField.js
+++ b/client/src/components/shared/PeopleField.js
@@ -1,6 +1,12 @@
 import React, { useState, useRef, useEffect, useLayoutEffect } from "react";
 import { useAppData } from "../../contexts/AppDataContext";
 import { RING_META, RING_LEVELS } from "../../helpers/ringMeta";
+import {
+  addVisibilityContact,
+  removeVisibilityContact,
+  toggleEveryone,
+  isEveryone,
+} from "../../helpers/visibilitySharing";
 import Avatar from "./Avatar";
 
 
@@ -132,6 +138,9 @@ function PeopleField({ mode, formData, setFormData, placeholder }) {
     if (mode === "recommend") {
       return formData.recommendedToContacts || [];
     }
+    if (mode === "visibility") {
+      return formData.visibilityContacts || [];
+    }
     return [];
   }
 
@@ -187,6 +196,8 @@ function PeopleField({ mode, formData, setFormData, placeholder }) {
           recommendedToContacts: [...current, contact.id],
         }));
       }
+    } else if (mode === "visibility") {
+      setFormData((prev) => addVisibilityContact(prev, contact.id));
     }
     setQuery("");
     inputRef.current?.focus();
@@ -208,6 +219,8 @@ function PeopleField({ mode, formData, setFormData, placeholder }) {
           (id) => id !== contactId
         ),
       }));
+    } else if (mode === "visibility") {
+      setFormData((prev) => removeVisibilityContact(prev, contactId));
     }
   }
 
@@ -319,8 +332,11 @@ function PeopleField({ mode, formData, setFormData, placeholder }) {
         }));
       }
     } else if (mode === "visibility") {
+      const visContacts = formData.visibilityContacts || [];
       const rings = formData.visibilityRings || [];
-      if (rings.length > 0) {
+      if (visContacts.length > 0) {
+        setFormData((prev) => removeVisibilityContact(prev, visContacts[visContacts.length - 1]));
+      } else if (rings.length > 0) {
         setFormData((prev) => ({
           ...prev,
           visibilityRings: rings.slice(0, -1),
@@ -382,6 +398,16 @@ function PeopleField({ mode, formData, setFormData, placeholder }) {
           <RingChip key={`ring-${level}`} level={level} onRemove={() => removeRing(level)} />
         );
       });
+      (formData.visibilityContacts || []).forEach((contactId) => {
+        const contact = contacts.find((c) => c.id === contactId);
+        chips.push(
+          <ContactChip
+            key={`contact-${contactId}`}
+            contact={contact}
+            onRemove={() => removeContact(contactId)}
+          />
+        );
+      });
     }
 
     return chips;
@@ -389,7 +415,9 @@ function PeopleField({ mode, formData, setFormData, placeholder }) {
 
   const chips = renderChips();
   const showRings = true;
-  const showContacts = mode === "companions" || mode === "recommend";
+  const showContacts = mode === "companions" || mode === "recommend" || mode === "visibility";
+  const showEveryone = mode === "visibility";
+  const everyoneActive = isEveryone(formData.visibilityRings);
 
   return (
     <div ref={containerRef} className="contact-picker-wrapper">
@@ -423,6 +451,24 @@ function PeopleField({ mode, formData, setFormData, placeholder }) {
             <div className="people-field-section">
               <div className="people-field-section-header">Select by Ring</div>
               <div className="people-field-rings">
+                {showEveryone && (
+                  <button
+                    type="button"
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      setFormData((prev) => toggleEveryone(prev));
+                    }}
+                    aria-pressed={everyoneActive}
+                    className="people-field-ring-btn"
+                    style={{
+                      background: everyoneActive ? "var(--color-primary)" : "var(--color-surface)",
+                      color: everyoneActive ? "#fff" : "var(--color-text-secondary)",
+                      borderColor: everyoneActive ? "var(--color-primary)" : "var(--color-border)",
+                    }}
+                  >
+                    🌐 Everyone
+                  </button>
+                )}
                 {RING_LEVELS.map((level) => {
                   const meta = RING_META[level];
                   const active = selectedRings.includes(level);

--- a/client/src/features/activities/activitySchema.js
+++ b/client/src/features/activities/activitySchema.js
@@ -1,6 +1,6 @@
 import { baseSchema } from "../../helpers/common.schema";
 import { getStatusField } from "../../helpers/statusLabels";
-import { getReflectionFields, getCompanionsField } from "../../helpers/reflection.schema";
+import { getReflectionFields, getCompanionsField, getVisibilityDefaults } from "../../helpers/reflection.schema";
 import { getLocationFields } from "../../helpers/location.schema";
 
 export const ACTIVITY_TYPES = {
@@ -129,6 +129,7 @@ const activityFields = [
 
   // Social (Companions + Visibility + Recommend)
   getCompanionsField("done"),
+  ...getVisibilityDefaults(),
   {
     name: "visibilityControl",
     label: "🔒 Who can see this",

--- a/client/src/features/cellar/cellarSchema.js
+++ b/client/src/features/cellar/cellarSchema.js
@@ -1,6 +1,6 @@
 import { baseSchema } from "../../helpers/common.schema";
 import { getStatusField } from "../../helpers/statusLabels";
-import { getReflectionFields, getCompanionsField } from "../../helpers/reflection.schema";
+import { getReflectionFields, getCompanionsField, getVisibilityDefaults } from "../../helpers/reflection.schema";
 
 export const WINE_TYPES = ["Red", "White", "Rosé", "Sparkling", "Dessert", "Fortified", "Orange"];
 
@@ -410,6 +410,7 @@ const cellarSchema = [
 
   // ── Social (Companions + Visibility + Recommend) ─────────────────────────
   getCompanionsField("tried"),
+  ...getVisibilityDefaults(),
   {
     name: "visibilityControl",
     label: "🔒 Who can see this",

--- a/client/src/features/events/eventSchema.js
+++ b/client/src/features/events/eventSchema.js
@@ -1,6 +1,6 @@
 import { baseSchema } from "../../helpers/common.schema";
 import { getStatusField } from "../../helpers/statusLabels";
-import { getReflectionFields, getCompanionsField } from "../../helpers/reflection.schema";
+import { getReflectionFields, getCompanionsField, getVisibilityDefaults } from "../../helpers/reflection.schema";
 import { getLocationFields } from "../../helpers/location.schema";
 
 export const EVENT_TYPES = [
@@ -292,6 +292,7 @@ const eventSchema = [
 
   // ── Social (Companions + Visibility + Recommend) ──────────────────────────
   getCompanionsField("attended"),
+  ...getVisibilityDefaults(),
   {
     name: "visibilityControl",
     label: "🔒 Who can see this",

--- a/client/src/features/movies/movieSchema.js
+++ b/client/src/features/movies/movieSchema.js
@@ -1,6 +1,6 @@
 import { baseSchema } from "../../helpers/common.schema";
 import { getStatusField } from "../../helpers/statusLabels";
-import { getReflectionFields, getCompanionsField } from "../../helpers/reflection.schema";
+import { getReflectionFields, getCompanionsField, getVisibilityDefaults } from "../../helpers/reflection.schema";
 
 const movieSchema = [
   getStatusField("movies"),
@@ -81,13 +81,7 @@ const movieSchema = [
 
   // Social (Companions + Visibility + Recommend)
   getCompanionsField("watched"),
-  {
-    name: "visibilityRings",
-    type: "hidden",
-    defaultValue: [1, 2, 3, 4],
-    section: "Hidden",
-    order: 64,
-  },
+  ...getVisibilityDefaults(),
   {
     name: "visibilityControl",
     label: "🔒 Who can see this",

--- a/client/src/features/travel/travelSchema.js
+++ b/client/src/features/travel/travelSchema.js
@@ -1,6 +1,6 @@
 import { baseSchema } from "../../helpers/common.schema";
 import { getStatusField } from "../../helpers/statusLabels";
-import { getReflectionFields, getCompanionsField } from "../../helpers/reflection.schema";
+import { getReflectionFields, getCompanionsField, getVisibilityDefaults } from "../../helpers/reflection.schema";
 import { getLocationFields } from "../../helpers/location.schema";
 
 const travelFields = [
@@ -88,6 +88,7 @@ const travelFields = [
 
   // ── Social (Companions + Visibility + Recommend) ───────────────────────────
   getCompanionsField("visited"),
+  ...getVisibilityDefaults(),
   {
     name: "visibilityControl",
     label: "🔒 Who can see this",

--- a/client/src/helpers/reflection.schema.js
+++ b/client/src/helpers/reflection.schema.js
@@ -59,6 +59,35 @@ export function getReflectionFields(experiencedStatus) {
 }
 
 /**
+ * Hidden state behind the "Who can see this" (visible-to) control.
+ *
+ * `visibilityRings` defaults to all four rings ("Everyone") so a new entry is
+ * shared with the user's whole network unless they narrow it. `visibilityContacts`
+ * holds individuals added directly (e.g. auto-added when collaborating) so they
+ * can be removed independently of any ring.
+ *
+ * Spread into a schema alongside its `visible-to` field.
+ */
+export function getVisibilityDefaults() {
+  return [
+    {
+      name: "visibilityRings",
+      type: "hidden",
+      defaultValue: [1, 2, 3, 4],
+      section: "Hidden",
+      order: 64,
+    },
+    {
+      name: "visibilityContacts",
+      type: "hidden",
+      defaultValue: [],
+      section: "Hidden",
+      order: 64,
+    },
+  ];
+}
+
+/**
  * Companions field for the Social section. Separated from getReflectionFields
  * so it can be grouped with visibility and recommendation controls.
  */

--- a/client/src/helpers/visibilitySharing.js
+++ b/client/src/helpers/visibilitySharing.js
@@ -1,0 +1,65 @@
+import { RING_LEVELS } from "./ringMeta";
+
+/**
+ * Cross-field rules linking "Who can see this" (visibilityRings +
+ * visibilityContacts) with the "Share & Collaborate" toggle
+ * (shareWithCompanionIds). Kept as pure functions over a formData object so the
+ * logic is testable and the components stay thin.
+ *
+ * Invariant: collaborate ⟹ visible.
+ *  - Enabling collaborate for someone adds them to "Who can see this".
+ *  - Disabling collaborate leaves them visible (user removes manually).
+ *  - Removing someone from "Who can see this" also stops collaborating with them
+ *    (you can't collaborate on something they can't see).
+ *  - "Who was there" (companions) is independent and never touched here.
+ */
+
+const uniq = (arr) => Array.from(new Set(arr));
+
+/** Add a contact to "Who can see this" (idempotent). */
+export function addVisibilityContact(formData, contactId) {
+  const current = formData.visibilityContacts || [];
+  if (current.includes(contactId)) return formData;
+  return { ...formData, visibilityContacts: [...current, contactId] };
+}
+
+/**
+ * Remove a contact from "Who can see this". Also drops any active collaborate
+ * share with them — they can't collaborate on an entry they can't see.
+ */
+export function removeVisibilityContact(formData, contactId) {
+  return {
+    ...formData,
+    visibilityContacts: (formData.visibilityContacts || []).filter((id) => id !== contactId),
+    shareWithCompanionIds: (formData.shareWithCompanionIds || []).filter((id) => id !== contactId),
+  };
+}
+
+/**
+ * Apply a new "Share & Collaborate" selection. Newly enabled collaborators are
+ * auto-added to "Who can see this"; disabling a collaborator does not remove
+ * their visibility (collaborate ⟹ visible, but not the reverse).
+ */
+export function applyCollaborateChange(formData, nextShareIds) {
+  const prevShareIds = formData.shareWithCompanionIds || [];
+  const added = nextShareIds.filter((id) => !prevShareIds.includes(id));
+  return {
+    ...formData,
+    shareWithCompanionIds: nextShareIds,
+    visibilityContacts: uniq([...(formData.visibilityContacts || []), ...added]),
+  };
+}
+
+/** True when every ring is selected — i.e. "Everyone" in the user's network. */
+export function isEveryone(visibilityRings) {
+  const set = new Set(visibilityRings || []);
+  return RING_LEVELS.every((level) => set.has(level));
+}
+
+/** Toggle the "Everyone" shortcut: select all rings, or clear them all. */
+export function toggleEveryone(formData) {
+  return {
+    ...formData,
+    visibilityRings: isEveryone(formData.visibilityRings) ? [] : [...RING_LEVELS],
+  };
+}

--- a/client/src/helpers/visibilitySharing.test.js
+++ b/client/src/helpers/visibilitySharing.test.js
@@ -1,0 +1,60 @@
+import {
+  addVisibilityContact,
+  removeVisibilityContact,
+  applyCollaborateChange,
+  isEveryone,
+  toggleEveryone,
+} from "./visibilitySharing";
+
+describe("visibilitySharing — collaborate ⟹ visible (#6)", () => {
+  test("enabling collaborate adds the person to Who can see this", () => {
+    const before = { shareWithCompanionIds: [], visibilityContacts: [] };
+    const after = applyCollaborateChange(before, ["c1"]);
+    expect(after.shareWithCompanionIds).toEqual(["c1"]);
+    expect(after.visibilityContacts).toContain("c1");
+  });
+
+  test("disabling collaborate leaves them visible (manual removal)", () => {
+    const before = { shareWithCompanionIds: ["c1"], visibilityContacts: ["c1"] };
+    const after = applyCollaborateChange(before, []);
+    expect(after.shareWithCompanionIds).toEqual([]);
+    expect(after.visibilityContacts).toEqual(["c1"]); // still visible
+  });
+
+  test("removing from Who can see this also turns collaborate off", () => {
+    const before = { shareWithCompanionIds: ["c1", "c2"], visibilityContacts: ["c1", "c2"] };
+    const after = removeVisibilityContact(before, "c1");
+    expect(after.visibilityContacts).toEqual(["c2"]);
+    expect(after.shareWithCompanionIds).toEqual(["c2"]); // c1 collaborate dropped
+  });
+
+  test("enabling collaborate does not duplicate an already-visible contact", () => {
+    const before = { shareWithCompanionIds: [], visibilityContacts: ["c1"] };
+    const after = applyCollaborateChange(before, ["c1"]);
+    expect(after.visibilityContacts).toEqual(["c1"]);
+  });
+
+  test("addVisibilityContact is idempotent and does not touch sharing", () => {
+    const before = { visibilityContacts: ["c1"], shareWithCompanionIds: [] };
+    expect(addVisibilityContact(before, "c1")).toBe(before);
+    const after = addVisibilityContact(before, "c2");
+    expect(after.visibilityContacts).toEqual(["c1", "c2"]);
+    expect(after.shareWithCompanionIds).toEqual([]);
+  });
+});
+
+describe("visibilitySharing — Everyone (#7)", () => {
+  test("isEveryone is true only when all rings are selected", () => {
+    expect(isEveryone([1, 2, 3, 4])).toBe(true);
+    expect(isEveryone([1, 2, 3])).toBe(false);
+    expect(isEveryone([])).toBe(false);
+  });
+
+  test("toggleEveryone selects all rings when not everyone", () => {
+    expect(toggleEveryone({ visibilityRings: [1] }).visibilityRings).toEqual([1, 2, 3, 4]);
+  });
+
+  test("toggleEveryone clears all rings when already everyone", () => {
+    expect(toggleEveryone({ visibilityRings: [1, 2, 3, 4] }).visibilityRings).toEqual([]);
+  });
+});

--- a/client/src/hooks/useCategory.js
+++ b/client/src/hooks/useCategory.js
@@ -266,7 +266,16 @@ export default function useCategory(category, { migrate, normalize, schema } = {
             const collaboratorStatuses = Object.fromEntries(
               shared.map((c) => [c.collaborator_contact_id, c.status])
             );
-            setFormData((prev) => ({ ...prev, shareWithCompanionIds: sharedContactIds, _collaboratorStatuses: collaboratorStatuses }));
+            setFormData((prev) => ({
+              ...prev,
+              shareWithCompanionIds: sharedContactIds,
+              // collaborate ⟹ visible: existing collaborators must show under
+              // "Who can see this" even on legacy entries saved before this field.
+              visibilityContacts: Array.from(
+                new Set([...(prev.visibilityContacts || []), ...sharedContactIds])
+              ),
+              _collaboratorStatuses: collaboratorStatuses,
+            }));
           }
         } catch {}
       }


### PR DESCRIPTION
Phase 2 of the Travel/Activity UX polish — the social-model rework. **Stacked on #7** (base branch is `feature/travel-activity-ux-polish-p1`); retarget to `main` after #7 merges.

## Items
- **#7 Everyone** — adds an "Everyone" pill (all four rings) to the visibility picker. New entries in Activities/Events/Travel/Movies/Cellar default to Everyone via a shared `getVisibilityDefaults()` schema factory. No new public/RLS concept — it's all rings.
- **#6 Collaborate ↔ Visibility** — "Who can see this" now holds **individuals** (`visibilityContacts`) in addition to rings. New pure helper `visibilitySharing.js` enforces **collaborate ⟹ visible**:
  - Enabling collaborate auto-adds the person to "Who can see this".
  - Disabling collaborate leaves them visible (manual removal).
  - Removing someone from "Who can see this" also turns collaborate off.
  - "Who was there" (companions) stays independent.
  - Existing collaborators hydrate into `visibilityContacts` on edit (form + detail panel) so legacy entries reflect the invariant.

## Verification
- `npx react-scripts build` — compiles clean.
- `react-scripts test` — full suite green (10 new tests covering the invariant transitions and Everyone toggle).
- Interactive checks (#6/#7 in the live form) need a local `.env` + data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)