### PR TITLE
feat: normalize filter/header components + fix Mine/Shared classifier

### DIFF
--- a/client/src/components/shared/CategoryListHeader.js
+++ b/client/src/components/shared/CategoryListHeader.js
@@ -2,6 +2,7 @@ import React from "react";
 import { Button } from "react-bootstrap";
 import StatsStrip from "./StatsStrip";
 import StatusToggle from "./StatusToggle";
+import YearFilter from "./YearFilter";
 import GroupedDropdownFilter from "./GroupedDropdownFilter";
 import SourceFilterPills from "./SourceFilterPills";
 
@@ -25,7 +26,12 @@ export default function CategoryListHeader({
   filterStatus,
   onStatusChange,
 
-  // Tabs (optional)
+  // YearFilter (optional — renders only when 2+ years exist)
+  yearOptions,
+  activeYear,
+  onYearChange,
+
+  // Tabs (optional view toggle, e.g. List/Map, Snaps/Photos)
   tabs,
   activeTab,
   onTabChange,
@@ -82,7 +88,29 @@ export default function CategoryListHeader({
         />
       )}
 
-      {/* Tabs (pill-style) */}
+      {/* YearFilter (renders null unless 2+ years available) */}
+      {yearOptions && onYearChange && (
+        <YearFilter
+          years={yearOptions}
+          value={activeYear}
+          onChange={onYearChange}
+        />
+      )}
+
+      {/* Custom extra filters (e.g. Kids ChildFilter, MilestoneTypeFilter) */}
+      {renderExtraFilters && renderExtraFilters()}
+
+      {/* GroupedDropdownFilter (category-specific pills) */}
+      {filterGroups && filterGroups.length > 0 && (
+        <GroupedDropdownFilter
+          groups={filterGroups}
+          value={filterValue}
+          onChange={onFilterChange}
+          color={filterColor || "var(--color-primary)"}
+        />
+      )}
+
+      {/* Tabs (pill-style view toggle, e.g. List/Map, Snaps/Photos) */}
       {tabs && tabs.length > 0 && (
         <div className="d-flex gap-2 mb-3">
           {tabs.map((tab) => (
@@ -106,19 +134,6 @@ export default function CategoryListHeader({
             </button>
           ))}
         </div>
-      )}
-
-      {/* Custom extra filters (e.g. Kids ChildFilter, MilestoneTypeFilter) */}
-      {renderExtraFilters && renderExtraFilters()}
-
-      {/* GroupedDropdownFilter */}
-      {filterGroups && filterGroups.length > 0 && (
-        <GroupedDropdownFilter
-          groups={filterGroups}
-          value={filterValue}
-          onChange={onFilterChange}
-          color={filterColor || "var(--color-primary)"}
-        />
       )}
 
       {/* SourceFilterPills */}

--- a/client/src/components/shared/EntryDetailPanel.js
+++ b/client/src/components/shared/EntryDetailPanel.js
@@ -32,6 +32,11 @@ function EntryDetailPanel({ item, category, schema, onClose, onSave, onDelete, r
         setFormData((prev) => ({
           ...prev,
           shareWithCompanionIds: sharedContactIds,
+          // collaborate ⟹ visible: surface existing collaborators under
+          // "Who can see this" even on entries saved before that field existed.
+          visibilityContacts: Array.from(
+            new Set([...(prev.visibilityContacts || []), ...sharedContactIds])
+          ),
           _collaboratorStatuses: collaboratorStatuses,
         }));
       } catch {

--- a/client/src/components/shared/ItemForm.js
+++ b/client/src/components/shared/ItemForm.js
@@ -10,6 +10,7 @@ import CountryDropdown from "./CountryDropdown";
 import CityAutocomplete from "./CityAutocomplete";
 import PeopleField from "./PeopleField";
 import ShareWithCompanionsToggle from "./ShareWithCompanionsToggle";
+import { applyCollaborateChange } from "../../helpers/visibilitySharing";
 import LinkedTripPicker from "./LinkedTripPicker";
 import PhotoUploadField from "./PhotoUploadField";
 import { getCountryContinent } from "../../data/countries";
@@ -759,10 +760,7 @@ function ItemForm({
                         value={formData.shareWithCompanionIds || []}
                         statuses={formData._collaboratorStatuses}
                         onChange={(ids) =>
-                          setFormData((prev) => ({
-                            ...prev,
-                            shareWithCompanionIds: ids,
-                          }))
+                          setFormData((prev) => applyCollaborateChange(prev, ids))
                         }
                       />
                     </Col>

--- a/client/src/components/shared/PeopleField.js
+++ b/client/src/components/shared/PeopleField.js
@@ -1,6 +1,12 @@
 import React, { useState, useRef, useEffect, useLayoutEffect } from "react";
 import { useAppData } from "../../contexts/AppDataContext";
 import { RING_META, RING_LEVELS } from "../../helpers/ringMeta";
+import {
+  addVisibilityContact,
+  removeVisibilityContact,
+  toggleEveryone,
+  isEveryone,
+} from "../../helpers/visibilitySharing";
 import Avatar from "./Avatar";
 
 
@@ -132,6 +138,9 @@ function PeopleField({ mode, formData, setFormData, placeholder }) {
     if (mode === "recommend") {
       return formData.recommendedToContacts || [];
     }
+    if (mode === "visibility") {
+      return formData.visibilityContacts || [];
+    }
     return [];
   }
 
@@ -187,6 +196,8 @@ function PeopleField({ mode, formData, setFormData, placeholder }) {
           recommendedToContacts: [...current, contact.id],
         }));
       }
+    } else if (mode === "visibility") {
+      setFormData((prev) => addVisibilityContact(prev, contact.id));
     }
     setQuery("");
     inputRef.current?.focus();
@@ -208,6 +219,8 @@ function PeopleField({ mode, formData, setFormData, placeholder }) {
           (id) => id !== contactId
         ),
       }));
+    } else if (mode === "visibility") {
+      setFormData((prev) => removeVisibilityContact(prev, contactId));
     }
   }
 
@@ -319,8 +332,11 @@ function PeopleField({ mode, formData, setFormData, placeholder }) {
         }));
       }
     } else if (mode === "visibility") {
+      const visContacts = formData.visibilityContacts || [];
       const rings = formData.visibilityRings || [];
-      if (rings.length > 0) {
+      if (visContacts.length > 0) {
+        setFormData((prev) => removeVisibilityContact(prev, visContacts[visContacts.length - 1]));
+      } else if (rings.length > 0) {
         setFormData((prev) => ({
           ...prev,
           visibilityRings: rings.slice(0, -1),
@@ -382,6 +398,16 @@ function PeopleField({ mode, formData, setFormData, placeholder }) {
           <RingChip key={`ring-${level}`} level={level} onRemove={() => removeRing(level)} />
         );
       });
+      (formData.visibilityContacts || []).forEach((contactId) => {
+        const contact = contacts.find((c) => c.id === contactId);
+        chips.push(
+          <ContactChip
+            key={`contact-${contactId}`}
+            contact={contact}
+            onRemove={() => removeContact(contactId)}
+          />
+        );
+      });
     }
 
     return chips;
@@ -389,7 +415,9 @@ function PeopleField({ mode, formData, setFormData, placeholder }) {
 
   const chips = renderChips();
   const showRings = true;
-  const showContacts = mode === "companions" || mode === "recommend";
+  const showContacts = mode === "companions" || mode === "recommend" || mode === "visibility";
+  const showEveryone = mode === "visibility";
+  const everyoneActive = isEveryone(formData.visibilityRings);
 
   return (
     <div ref={containerRef} className="contact-picker-wrapper">
@@ -423,6 +451,24 @@ function PeopleField({ mode, formData, setFormData, placeholder }) {
             <div className="people-field-section">
               <div className="people-field-section-header">Select by Ring</div>
               <div className="people-field-rings">
+                {showEveryone && (
+                  <button
+                    type="button"
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      setFormData((prev) => toggleEveryone(prev));
+                    }}
+                    aria-pressed={everyoneActive}
+                    className="people-field-ring-btn"
+                    style={{
+                      background: everyoneActive ? "var(--color-primary)" : "var(--color-surface)",
+                      color: everyoneActive ? "#fff" : "var(--color-text-secondary)",
+                      borderColor: everyoneActive ? "var(--color-primary)" : "var(--color-border)",
+                    }}
+                  >
+                    🌐 Everyone
+                  </button>
+                )}
                 {RING_LEVELS.map((level) => {
                   const meta = RING_META[level];
                   const active = selectedRings.includes(level);

--- a/client/src/components/shared/StatsStrip.js
+++ b/client/src/components/shared/StatsStrip.js
@@ -48,7 +48,7 @@ function StatsStrip({ stats, icon, statsLink }) {
           onMouseEnter={(e) => { e.currentTarget.style.background = "var(--color-surface-hover)"; }}
           onMouseLeave={(e) => { e.currentTarget.style.background = "none"; }}
         >
-          Stats &rarr;
+          Full Stats &rarr;
         </Link>
       )}
     </div>

--- a/client/src/components/shared/YearFilter.js
+++ b/client/src/components/shared/YearFilter.js
@@ -1,0 +1,37 @@
+import React from "react";
+
+/**
+ * Standard Year filter pill row, shared across category lists and aggregate
+ * pages (Timeline, My Memories, Shared, Recommendations). Reuses the
+ * `.status-toggle` pill styling so it matches the Attended/Wishlist row.
+ *
+ * Renders nothing unless there are at least two years to choose between — a
+ * single-year list gains nothing from a year filter.
+ */
+function YearFilter({ years, value, onChange }) {
+  if (!years || years.length < 2) return null;
+
+  return (
+    <div className="status-toggle mb-2" role="group" aria-label="Year filter">
+      <button
+        type="button"
+        className={`btn btn-sm ${value === "all" ? "active" : ""}`}
+        onClick={() => onChange("all")}
+      >
+        All
+      </button>
+      {years.map((year) => (
+        <button
+          key={year}
+          type="button"
+          className={`btn btn-sm ${value === String(year) ? "active" : ""}`}
+          onClick={() => onChange(String(year))}
+        >
+          {year}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default YearFilter;

--- a/client/src/features/activities/activitySchema.js
+++ b/client/src/features/activities/activitySchema.js
@@ -1,6 +1,6 @@
 import { baseSchema } from "../../helpers/common.schema";
 import { getStatusField } from "../../helpers/statusLabels";
-import { getReflectionFields, getCompanionsField } from "../../helpers/reflection.schema";
+import { getReflectionFields, getCompanionsField, getVisibilityDefaults } from "../../helpers/reflection.schema";
 import { getLocationFields } from "../../helpers/location.schema";
 
 export const ACTIVITY_TYPES = {
@@ -129,6 +129,7 @@ const activityFields = [
 
   // Social (Companions + Visibility + Recommend)
   getCompanionsField("done"),
+  ...getVisibilityDefaults(),
   {
     name: "visibilityControl",
     label: "🔒 Who can see this",

--- a/client/src/features/activities/components/ActivityList.js
+++ b/client/src/features/activities/components/ActivityList.js
@@ -1,5 +1,4 @@
 import React, { useEffect } from "react";
-import { isMineOnly, isSharedSource } from "../../../helpers/operator";
 import { Button } from "react-bootstrap";
 import { useLocation } from "react-router-dom";
 import ActivityForm from "./ActivityForm";
@@ -13,17 +12,25 @@ import CategoryListHeader from "../../../components/shared/CategoryListHeader";
 import { RATING_GROUP } from "../../../components/shared/GroupedDropdownFilter";
 import activitySchema, { ACTIVITY_TYPES } from "../activitySchema";
 import useCategory from "../../../hooks/useCategory";
+import useListFilters from "../../../hooks/useListFilters";
 import { useAppData } from "../../../contexts/AppDataContext";
 import {
   getStatusFilterOptions,
   filterByStatus,
-  getInitialSourceFilter,
 } from "../../../helpers/filterUtils";
+
+// Single "Type" pill listing every activity sub-category (Movie-style filter UX).
+const ACTIVITY_TYPE_GROUP = {
+  key: "activityType",
+  label: "\u{1F3D4}️ Type",
+  options: Object.values(ACTIVITY_TYPES).flatMap((g) =>
+    g.options.map((opt) => ({ value: opt, label: opt }))
+  ),
+};
 
 function ActivityList() {
   const location = useLocation();
   const [activityTypeFilter, setActivityTypeFilter] = React.useState("all");
-  const [sourceFilter, setSourceFilter] = React.useState(getInitialSourceFilter);
   const { profile } = useAppData();
 
   const {
@@ -38,6 +45,8 @@ function ActivityList() {
     viewDetailItem, setViewDetailItem, saveDetailEdit,
   } = useCategory("activities", { schema: activitySchema });
 
+  const lf = useListFilters(activities, { dateField: "startDate" });
+
   useEffect(() => {
     const pre = location.state?.prefilledTripTitle;
     if (pre) {
@@ -47,18 +56,12 @@ function ActivityList() {
 
   const activityStatuses = getStatusFilterOptions("activities");
   const statusFiltered = filterByStatus(activities, filterStatus);
-  const sourceFiltered = sourceFilter === "mine"
-    ? statusFiltered.filter(isMineOnly)
-    : sourceFilter === "shared"
-    ? statusFiltered.filter(isSharedSource)
-    : sourceFilter === "recommended"
-    ? statusFiltered.filter((i) => i._isRecommended)
-    : statusFiltered;
+  const commonFiltered = lf.applyCommonFilters(statusFiltered);
   const filteredActivities = React.useMemo(() => {
-    if (activityTypeFilter === "all") return sourceFiltered;
+    if (activityTypeFilter === "all") return commonFiltered;
     if (activityTypeFilter.startsWith("rating:")) {
       const rVal = activityTypeFilter.split(":")[1];
-      return sourceFiltered.filter((i) => {
+      return commonFiltered.filter((i) => {
         const r = parseInt(i.rating, 10);
         if (rVal === "unrated") return !r;
         if (rVal === "5") return r === 5;
@@ -67,10 +70,8 @@ function ActivityList() {
         return true;
       });
     }
-    return sourceFiltered.filter((i) => i.activityType === activityTypeFilter);
-  }, [sourceFiltered, activityTypeFilter]);
-  const sharedCount = activities.filter(isSharedSource).length;
-  const recommendedCount = activities.filter((i) => i._isRecommended).length;
+    return commonFiltered.filter((i) => i.activityType === activityTypeFilter);
+  }, [commonFiltered, activityTypeFilter]);
 
   const done = activities.filter((i) => i.status === "done");
 
@@ -98,22 +99,18 @@ function ActivityList() {
         statusOptions={activityStatuses}
         filterStatus={filterStatus}
         onStatusChange={setFilterStatus}
-        filterGroups={[
-          ...Object.entries(ACTIVITY_TYPES).map(([key, g]) => ({
-            key,
-            label: g.label,
-            options: g.options.map((opt) => ({ value: opt, label: opt })),
-          })),
-          RATING_GROUP,
-        ]}
+        yearOptions={lf.yearOptions}
+        activeYear={lf.activeYear}
+        onYearChange={lf.setActiveYear}
+        filterGroups={[ACTIVITY_TYPE_GROUP, RATING_GROUP]}
         filterValue={activityTypeFilter}
         onFilterChange={setActivityTypeFilter}
         filterColor="var(--color-activities, #2EB67D)"
-        sourceFilter={sourceFilter}
-        onSourceChange={setSourceFilter}
+        sourceFilter={lf.sourceFilter}
+        onSourceChange={lf.setSourceFilter}
         avatarUrl={profile?.avatar_url}
-        sharedCount={sharedCount}
-        recommendedCount={recommendedCount}
+        sharedCount={lf.sharedCount}
+        recommendedCount={lf.recommendedCount}
       />
 
       {filteredActivities.length === 0 && !loading && (

--- a/client/src/features/cars/components/CarList.js
+++ b/client/src/features/cars/components/CarList.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { isMineOnly, isSharedSource } from "../../../helpers/operator";
 import { Button } from "react-bootstrap";
 import CarForm from "../../../features/cars/components/CarForm";
 import ItemCardList from "../../../components/shared/ItemCardList";
@@ -11,16 +10,15 @@ import CategoryListHeader from "../../../components/shared/CategoryListHeader";
 import { RATING_GROUP } from "../../../components/shared/GroupedDropdownFilter";
 import carSchema from "../../../features/cars/carSchema";
 import useCategory from "../../../hooks/useCategory";
+import useListFilters from "../../../hooks/useListFilters";
 import { useAppData } from "../../../contexts/AppDataContext";
 import {
   getStatusFilterOptions,
   filterByStatus,
   getStatusLabel,
-  getInitialSourceFilter,
 } from "../../../helpers/filterUtils";
 
 function CarList() {
-  const [sourceFilter, setSourceFilter] = React.useState(getInitialSourceFilter);
   const [carFilter, setCarFilter] = React.useState("all");
   const { profile } = useAppData();
   const {
@@ -37,19 +35,14 @@ function CarList() {
 
   const carStatuses = getStatusFilterOptions("cars");
   const statusFiltered = filterByStatus(cars, filterStatus);
-  const sourceFiltered = sourceFilter === "mine"
-    ? statusFiltered.filter(isMineOnly)
-    : sourceFilter === "shared"
-    ? statusFiltered.filter(isSharedSource)
-    : sourceFilter === "recommended"
-    ? statusFiltered.filter((i) => i._isRecommended)
-    : statusFiltered;
+  const lf = useListFilters(cars, { dateField: "startDate" });
+  const commonFiltered = lf.applyCommonFilters(statusFiltered);
 
   const filteredCars = React.useMemo(() => {
-    if (carFilter === "all") return sourceFiltered;
+    if (carFilter === "all") return commonFiltered;
     if (carFilter.startsWith("rating:")) {
       const rVal = carFilter.split(":")[1];
-      return sourceFiltered.filter((i) => {
+      return commonFiltered.filter((i) => {
         const r = parseInt(i.rating, 10);
         if (rVal === "unrated") return !r;
         if (rVal === "5") return r === 5;
@@ -58,11 +51,9 @@ function CarList() {
         return true;
       });
     }
-    return sourceFiltered;
-  }, [sourceFiltered, carFilter]);
+    return commonFiltered;
+  }, [commonFiltered, carFilter]);
 
-  const sharedCount = cars.filter(isSharedSource).length;
-  const recommendedCount = cars.filter((i) => i._isRecommended).length;
   const sectionTitle = `Cars - ${getStatusLabel("cars", filterStatus)}`;
 
   return (
@@ -78,15 +69,18 @@ function CarList() {
         statusOptions={carStatuses}
         filterStatus={filterStatus}
         onStatusChange={setFilterStatus}
+        yearOptions={lf.yearOptions}
+        activeYear={lf.activeYear}
+        onYearChange={lf.setActiveYear}
         filterGroups={[RATING_GROUP]}
         filterValue={carFilter}
         onFilterChange={setCarFilter}
         filterColor="var(--color-cars, #36C5F0)"
-        sourceFilter={sourceFilter}
-        onSourceChange={setSourceFilter}
+        sourceFilter={lf.sourceFilter}
+        onSourceChange={lf.setSourceFilter}
         avatarUrl={profile?.avatar_url}
-        sharedCount={sharedCount}
-        recommendedCount={recommendedCount}
+        sharedCount={lf.sharedCount}
+        recommendedCount={lf.recommendedCount}
       />
 
       {filteredCars.length === 0 && !loading && (

--- a/client/src/features/cellar/cellarSchema.js
+++ b/client/src/features/cellar/cellarSchema.js
@@ -1,6 +1,6 @@
 import { baseSchema } from "../../helpers/common.schema";
 import { getStatusField } from "../../helpers/statusLabels";
-import { getReflectionFields, getCompanionsField } from "../../helpers/reflection.schema";
+import { getReflectionFields, getCompanionsField, getVisibilityDefaults } from "../../helpers/reflection.schema";
 
 export const WINE_TYPES = ["Red", "White", "Rosé", "Sparkling", "Dessert", "Fortified", "Orange"];
 
@@ -410,6 +410,7 @@ const cellarSchema = [
 
   // ── Social (Companions + Visibility + Recommend) ─────────────────────────
   getCompanionsField("tried"),
+  ...getVisibilityDefaults(),
   {
     name: "visibilityControl",
     label: "🔒 Who can see this",

--- a/client/src/features/cellar/components/CellarList.js
+++ b/client/src/features/cellar/components/CellarList.js
@@ -1,5 +1,4 @@
 import React, { useState, useMemo } from "react";
-import { isMineOnly, isSharedSource } from "../../../helpers/operator";
 import { Button } from "react-bootstrap";
 import CellarForm from "./CellarForm";
 import ItemCardList from "../../../components/shared/ItemCardList";
@@ -11,11 +10,11 @@ import CategoryListHeader from "../../../components/shared/CategoryListHeader";
 import { RATING_GROUP } from "../../../components/shared/GroupedDropdownFilter";
 import cellarSchema, { WINE_TYPES, WHISKEY_TYPES } from "../cellarSchema";
 import useCategory from "../../../hooks/useCategory";
+import useListFilters from "../../../hooks/useListFilters";
 import { useAppData } from "../../../contexts/AppDataContext";
 import {
   getStatusFilterOptions,
   filterByStatus,
-  getInitialSourceFilter,
 } from "../../../helpers/filterUtils";
 
 const WINE_TYPE_EMOJIS = {
@@ -28,16 +27,8 @@ const WHISKEY_TYPE_EMOJIS = {
   Japanese: "\u{1F1EF}\u{1F1F5}", Canadian: "\u{1F1E8}\u{1F1E6}", Other: "\u{1F4CC}",
 };
 
-const CELLAR_TABS = [
-  { id: "all", label: "All" },
-  { id: "wine", label: "\u{1F377} Wine" },
-  { id: "whiskey", label: "\u{1F943} Whiskey" },
-];
-
 function CellarList() {
-  const [activeTab, setActiveTab] = useState("all");
   const [subFilter, setSubFilter] = useState("all");
-  const [sourceFilter, setSourceFilter] = useState(getInitialSourceFilter);
   const { profile } = useAppData();
 
   const {
@@ -67,6 +58,8 @@ function CellarList() {
 
   const cellarStatuses = getStatusFilterOptions("cellar");
   const statusFiltered = filterByStatus(cellarItems, filterStatus);
+  const lf = useListFilters(cellarItems, { dateField: "startDate" });
+  const commonFiltered = lf.applyCommonFilters(statusFiltered);
 
   const availableVarietals = useMemo(() => {
     const wineItems = cellarItems.filter((i) => (i.subType || "wine") === "wine" && i.varietal);
@@ -74,74 +67,65 @@ function CellarList() {
     return [...varietalSet].sort();
   }, [cellarItems]);
 
-  const subFilterGroups = useMemo(() => {
-    if (activeTab === "wine") {
-      const groups = [
-        {
-          key: "type",
-          label: "\u{1F377} Type",
-          options: WINE_TYPES.map((t) => ({
-            value: `wine:${t}`,
-            label: `${WINE_TYPE_EMOJIS[t] || "\u{1F377}"} ${t}`,
-          })),
-        },
-      ];
-      if (availableVarietals.length > 0) {
-        groups.push({
-          key: "varietal",
-          label: "\u{1F347} Varietal",
-          options: availableVarietals.map((v) => ({ value: `varietal:${v}`, label: v })),
-        });
-      }
-      groups.push(RATING_GROUP);
-      return groups;
+  // Single-select pill model (Movie-style): one "Type" pill for Wine/Whiskey,
+  // plus dependent sub-type / varietal / rating pills, all sharing one value.
+  const cellarFilterGroups = useMemo(() => {
+    const groups = [
+      {
+        key: "subtype",
+        label: "\u{1F37E} Type",
+        options: [
+          { value: "subtype:wine", label: "\u{1F377} Wine" },
+          { value: "subtype:whiskey", label: "\u{1F943} Whiskey" },
+        ],
+      },
+      {
+        key: "wineType",
+        label: "\u{1F347} Wine Type",
+        options: WINE_TYPES.map((t) => ({
+          value: `wine:${t}`,
+          label: `${WINE_TYPE_EMOJIS[t] || "\u{1F377}"} ${t}`,
+        })),
+      },
+    ];
+    if (availableVarietals.length > 0) {
+      groups.push({
+        key: "varietal",
+        label: "\u{1F377} Varietal",
+        options: availableVarietals.map((v) => ({ value: `varietal:${v}`, label: v })),
+      });
     }
-    if (activeTab === "whiskey") {
-      return [
-        {
-          key: "type",
-          label: "\u{1F943} Type",
-          options: WHISKEY_TYPES.map((t) => ({
-            value: `whiskey:${t}`,
-            label: `${WHISKEY_TYPE_EMOJIS[t] || "\u{1F943}"} ${t}`,
-          })),
-        },
-        RATING_GROUP,
-      ];
-    }
-    return [RATING_GROUP];
-  }, [activeTab, availableVarietals]);
+    groups.push({
+      key: "whiskeyType",
+      label: "\u{1F943} Whiskey Type",
+      options: WHISKEY_TYPES.map((t) => ({
+        value: `whiskey:${t}`,
+        label: `${WHISKEY_TYPE_EMOJIS[t] || "\u{1F943}"} ${t}`,
+      })),
+    });
+    groups.push(RATING_GROUP);
+    return groups;
+  }, [availableVarietals]);
 
   const filteredItems = useMemo(() => {
-    let items = statusFiltered;
-    if (sourceFilter === "mine") items = items.filter(isMineOnly);
-    else if (sourceFilter === "shared") items = items.filter(isSharedSource);
-    else if (sourceFilter === "recommended") items = items.filter((i) => i._isRecommended);
-
-    if (activeTab === "wine") items = items.filter((i) => (i.subType || "wine") === "wine");
-    else if (activeTab === "whiskey") items = items.filter((i) => i.subType === "whiskey");
-
-    if (subFilter !== "all") {
-      const [type, val] = subFilter.split(":");
-      if (type === "wine") {
-        items = items.filter((i) => i.wineType === val);
-      } else if (type === "whiskey") {
-        items = items.filter((i) => i.whiskyType === val);
-      } else if (type === "varietal") {
-        items = items.filter((i) => i.varietal === val);
-      } else if (type === "rating") {
-        items = items.filter((i) => {
-          const r = parseInt(i.rating, 10);
-          if (val === "unrated") return !r;
-          if (val === "5") return r === 5;
-          if (val === "4+") return r >= 4;
-          if (val === "3+") return r >= 3;
-          return true;
-        });
-      }
+    if (subFilter === "all") return commonFiltered;
+    const [type, val] = subFilter.split(":");
+    if (type === "subtype") return commonFiltered.filter((i) => (i.subType || "wine") === val);
+    if (type === "wine") return commonFiltered.filter((i) => i.wineType === val);
+    if (type === "whiskey") return commonFiltered.filter((i) => i.whiskyType === val);
+    if (type === "varietal") return commonFiltered.filter((i) => i.varietal === val);
+    if (type === "rating") {
+      return commonFiltered.filter((i) => {
+        const r = parseInt(i.rating, 10);
+        if (val === "unrated") return !r;
+        if (val === "5") return r === 5;
+        if (val === "4+") return r >= 4;
+        if (val === "3+") return r >= 3;
+        return true;
+      });
     }
-    return items;
-  }, [statusFiltered, sourceFilter, activeTab, subFilter]);
+    return commonFiltered;
+  }, [commonFiltered, subFilter]);
 
   const getItemIcon = (item) => {
     return (item.subType || "wine") === "whiskey" ? "\u{1F943}" : "\u{1F377}";
@@ -151,11 +135,6 @@ function CellarList() {
   const totalBottles = cellarItems
     .filter((i) => i.status === "cellar")
     .reduce((sum, i) => sum + (Number(i.bottleCount) || 1), 0);
-
-  const handleTabChange = (tabId) => {
-    setActiveTab(tabId);
-    setSubFilter("all");
-  };
 
   return (
     <>
@@ -174,19 +153,18 @@ function CellarList() {
         statusOptions={cellarStatuses}
         filterStatus={filterStatus}
         onStatusChange={setFilterStatus}
-        tabs={CELLAR_TABS}
-        activeTab={activeTab}
-        onTabChange={handleTabChange}
-        tabColor="var(--color-cellar, #8B3A8F)"
-        filterGroups={subFilterGroups}
+        yearOptions={lf.yearOptions}
+        activeYear={lf.activeYear}
+        onYearChange={lf.setActiveYear}
+        filterGroups={cellarFilterGroups}
         filterValue={subFilter}
         onFilterChange={setSubFilter}
         filterColor="var(--color-cellar, #8B3A8F)"
-        sourceFilter={sourceFilter}
-        onSourceChange={setSourceFilter}
+        sourceFilter={lf.sourceFilter}
+        onSourceChange={lf.setSourceFilter}
         avatarUrl={profile?.avatar_url}
-        sharedCount={cellarItems.filter(isSharedSource).length}
-        recommendedCount={cellarItems.filter((i) => i._isRecommended).length}
+        sharedCount={lf.sharedCount}
+        recommendedCount={lf.recommendedCount}
       />
 
       {filteredItems.length === 0 && !loading && (

--- a/client/src/features/events/components/EventList.js
+++ b/client/src/features/events/components/EventList.js
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useRef, useMemo } from "react";
-import { isMineOnly, isSharedSource } from "../../../helpers/operator";
 import { Button } from "react-bootstrap";
 import eventSchema, { EVENT_TYPES } from "../eventSchema";
 import EventForm from "./EventForm";
@@ -11,6 +10,7 @@ import EntryDetailPanel from "../../../components/shared/EntryDetailPanel";
 import CategoryListHeader from "../../../components/shared/CategoryListHeader";
 import { RATING_GROUP } from "../../../components/shared/GroupedDropdownFilter";
 import useCategory from "../../../hooks/useCategory";
+import useListFilters from "../../../hooks/useListFilters";
 import { useAppData } from "../../../contexts/AppDataContext";
 import dataService from "../../../services/dataService";
 
@@ -18,7 +18,6 @@ import {
   getStatusFilterOptions,
   filterByStatus,
   getStatusLabel,
-  getInitialSourceFilter,
 } from "../../../helpers/filterUtils";
 
 const typeLabels = EVENT_TYPES.reduce((acc, t) => {
@@ -48,7 +47,6 @@ function normalizeEvent(data) {
 }
 
 function EventList() {
-  const [sourceFilter, setSourceFilter] = React.useState(getInitialSourceFilter);
   const [filterType, setFilterType] = useState("all");
   const { profile } = useAppData();
   const {
@@ -97,19 +95,14 @@ function EventList() {
 
   const eventStatuses = getStatusFilterOptions("events");
   const statusFiltered = filterByStatus(events, filterStatus);
-  const sourceFiltered = sourceFilter === "mine"
-    ? statusFiltered.filter(isMineOnly)
-    : sourceFilter === "shared"
-    ? statusFiltered.filter(isSharedSource)
-    : sourceFilter === "recommended"
-    ? statusFiltered.filter((i) => i._isRecommended)
-    : statusFiltered;
+  const lf = useListFilters(events, { dateField: "startDate" });
+  const commonFiltered = lf.applyCommonFilters(statusFiltered);
 
   const filteredEvents = useMemo(() => {
-    if (filterType === "all") return sourceFiltered;
+    if (filterType === "all") return commonFiltered;
     if (filterType.startsWith("rating:")) {
       const rVal = filterType.split(":")[1];
-      return sourceFiltered.filter((i) => {
+      return commonFiltered.filter((i) => {
         const r = parseInt(i.rating, 10);
         if (rVal === "unrated") return !r;
         if (rVal === "5") return r === 5;
@@ -118,11 +111,9 @@ function EventList() {
         return true;
       });
     }
-    return sourceFiltered.filter((i) => i.eventType === filterType);
-  }, [sourceFiltered, filterType]);
+    return commonFiltered.filter((i) => i.eventType === filterType);
+  }, [commonFiltered, filterType]);
 
-  const sharedCount = events.filter(isSharedSource).length;
-  const recommendedCount = events.filter((i) => i._isRecommended).length;
   const sectionTitle = `Events - ${getStatusLabel("events", filterStatus)}`;
 
   const eventFilterGroups = useMemo(() => [
@@ -166,15 +157,18 @@ function EventList() {
         statusOptions={eventStatuses}
         filterStatus={filterStatus}
         onStatusChange={setFilterStatus}
+        yearOptions={lf.yearOptions}
+        activeYear={lf.activeYear}
+        onYearChange={lf.setActiveYear}
         filterGroups={eventFilterGroups}
         filterValue={filterType}
         onFilterChange={setFilterType}
         filterColor="var(--color-events)"
-        sourceFilter={sourceFilter}
-        onSourceChange={setSourceFilter}
+        sourceFilter={lf.sourceFilter}
+        onSourceChange={lf.setSourceFilter}
         avatarUrl={profile?.avatar_url}
-        sharedCount={sharedCount}
-        recommendedCount={recommendedCount}
+        sharedCount={lf.sharedCount}
+        recommendedCount={lf.recommendedCount}
       />
 
       {filteredEvents.length === 0 && !showForm && !loading && (

--- a/client/src/features/events/eventSchema.js
+++ b/client/src/features/events/eventSchema.js
@@ -1,6 +1,6 @@
 import { baseSchema } from "../../helpers/common.schema";
 import { getStatusField } from "../../helpers/statusLabels";
-import { getReflectionFields, getCompanionsField } from "../../helpers/reflection.schema";
+import { getReflectionFields, getCompanionsField, getVisibilityDefaults } from "../../helpers/reflection.schema";
 import { getLocationFields } from "../../helpers/location.schema";
 
 export const EVENT_TYPES = [
@@ -292,6 +292,7 @@ const eventSchema = [
 
   // ── Social (Companions + Visibility + Recommend) ──────────────────────────
   getCompanionsField("attended"),
+  ...getVisibilityDefaults(),
   {
     name: "visibilityControl",
     label: "🔒 Who can see this",

--- a/client/src/features/homes/components/HomeList.js
+++ b/client/src/features/homes/components/HomeList.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { isMineOnly, isSharedSource } from "../../../helpers/operator";
 import { Button } from "react-bootstrap";
 import HomeForm from "../../../features/homes/components/HomeForm";
 import ItemCardList from "../../../components/shared/ItemCardList";
@@ -11,16 +10,15 @@ import CategoryListHeader from "../../../components/shared/CategoryListHeader";
 import { RATING_GROUP } from "../../../components/shared/GroupedDropdownFilter";
 import homeSchema from "../../../features/homes/homeSchema";
 import useCategory from "../../../hooks/useCategory";
+import useListFilters from "../../../hooks/useListFilters";
 import { useAppData } from "../../../contexts/AppDataContext";
 import {
   getStatusFilterOptions,
   filterByStatus,
   getStatusLabel,
-  getInitialSourceFilter,
 } from "../../../helpers/filterUtils";
 
 function HomeList() {
-  const [sourceFilter, setSourceFilter] = React.useState(getInitialSourceFilter);
   const [homeFilter, setHomeFilter] = React.useState("all");
   const { profile } = useAppData();
   const {
@@ -37,19 +35,14 @@ function HomeList() {
 
   const homeStatuses = getStatusFilterOptions("homes");
   const statusFiltered = filterByStatus(homes, filterStatus);
-  const sourceFiltered = sourceFilter === "mine"
-    ? statusFiltered.filter(isMineOnly)
-    : sourceFilter === "shared"
-    ? statusFiltered.filter(isSharedSource)
-    : sourceFilter === "recommended"
-    ? statusFiltered.filter((i) => i._isRecommended)
-    : statusFiltered;
+  const lf = useListFilters(homes, { dateField: "startDate" });
+  const commonFiltered = lf.applyCommonFilters(statusFiltered);
 
   const filteredHomes = React.useMemo(() => {
-    if (homeFilter === "all") return sourceFiltered;
+    if (homeFilter === "all") return commonFiltered;
     if (homeFilter.startsWith("rating:")) {
       const rVal = homeFilter.split(":")[1];
-      return sourceFiltered.filter((i) => {
+      return commonFiltered.filter((i) => {
         const r = parseInt(i.rating, 10);
         if (rVal === "unrated") return !r;
         if (rVal === "5") return r === 5;
@@ -58,11 +51,9 @@ function HomeList() {
         return true;
       });
     }
-    return sourceFiltered;
-  }, [sourceFiltered, homeFilter]);
+    return commonFiltered;
+  }, [commonFiltered, homeFilter]);
 
-  const sharedCount = homes.filter(isSharedSource).length;
-  const recommendedCount = homes.filter((i) => i._isRecommended).length;
   const sectionTitle = `Homes - ${getStatusLabel("homes", filterStatus)}`;
 
   return (
@@ -78,15 +69,18 @@ function HomeList() {
         statusOptions={homeStatuses}
         filterStatus={filterStatus}
         onStatusChange={setFilterStatus}
+        yearOptions={lf.yearOptions}
+        activeYear={lf.activeYear}
+        onYearChange={lf.setActiveYear}
         filterGroups={[RATING_GROUP]}
         filterValue={homeFilter}
         onFilterChange={setHomeFilter}
         filterColor="var(--color-homes, #2EB67D)"
-        sourceFilter={sourceFilter}
-        onSourceChange={setSourceFilter}
+        sourceFilter={lf.sourceFilter}
+        onSourceChange={lf.setSourceFilter}
         avatarUrl={profile?.avatar_url}
-        sharedCount={sharedCount}
-        recommendedCount={recommendedCount}
+        sharedCount={lf.sharedCount}
+        recommendedCount={lf.recommendedCount}
       />
 
       {filteredHomes.length === 0 && !loading && (

--- a/client/src/features/kids/components/KidsList.js
+++ b/client/src/features/kids/components/KidsList.js
@@ -1,5 +1,4 @@
 import React, { useMemo } from "react";
-import { isMineOnly, isSharedSource } from "../../../helpers/operator";
 import { Button } from "react-bootstrap";
 import KidsForm from "./KidsForm";
 import ItemCardList from "../../../components/shared/ItemCardList";
@@ -11,11 +10,11 @@ import CategoryListHeader from "../../../components/shared/CategoryListHeader";
 import { RATING_GROUP } from "../../../components/shared/GroupedDropdownFilter";
 import kidsSchema, { KIDS_EVENT_TYPES } from "../kidsSchema";
 import useCategory from "../../../hooks/useCategory";
+import useListFilters from "../../../hooks/useListFilters";
 import { useAppData } from "../../../contexts/AppDataContext";
 import {
   getStatusFilterOptions,
   filterByStatus,
-  getInitialSourceFilter,
 } from "../../../helpers/filterUtils";
 
 function getAgeAtDate(birthday, eventDate) {
@@ -170,7 +169,6 @@ function KidsList() {
   const { contacts, profile } = useAppData();
   const [milestoneTypeFilter, setMilestoneTypeFilter] = React.useState("all");
   const [childFilter, setChildFilter] = React.useState("all");
-  const [sourceFilter, setSourceFilter] = React.useState(getInitialSourceFilter);
   const [ratingFilter, setRatingFilter] = React.useState("all");
 
   const {
@@ -185,19 +183,13 @@ function KidsList() {
     viewDetailItem, setViewDetailItem,
   } = useCategory("kids", { schema: kidsSchema });
 
+  const lf = useListFilters(milestones, { dateField: ["startDate", "createdAt"] });
   const kidsStatuses = getStatusFilterOptions("kids");
   const statusFiltered = filterByStatus(milestones, filterStatus);
-
-  const sourceFiltered = sourceFilter === "mine"
-    ? statusFiltered.filter(isMineOnly)
-    : sourceFilter === "shared"
-    ? statusFiltered.filter(isSharedSource)
-    : sourceFilter === "recommended"
-    ? statusFiltered.filter((i) => i._isRecommended)
-    : statusFiltered;
+  const commonFiltered = lf.applyCommonFilters(statusFiltered);
 
   const filtered = useMemo(() => {
-    let items = sourceFiltered
+    let items = commonFiltered
       .filter((i) => milestoneTypeFilter === "all" || i.milestoneType === milestoneTypeFilter)
       .filter((i) => childFilter === "all" || i.childContactId === childFilter);
     if (ratingFilter !== "all" && ratingFilter.startsWith("rating:")) {
@@ -212,10 +204,7 @@ function KidsList() {
       });
     }
     return items;
-  }, [sourceFiltered, milestoneTypeFilter, childFilter, ratingFilter]);
-
-  const sharedCount = milestones.filter(isSharedSource).length;
-  const recommendedCount = milestones.filter((i) => i._isRecommended).length;
+  }, [commonFiltered, milestoneTypeFilter, childFilter, ratingFilter]);
 
   const groupedByYear = useMemo(() => {
     const groups = {};
@@ -263,6 +252,9 @@ function KidsList() {
         statusOptions={kidsStatuses}
         filterStatus={filterStatus}
         onStatusChange={setFilterStatus}
+        yearOptions={lf.yearOptions}
+        activeYear={lf.activeYear}
+        onYearChange={lf.setActiveYear}
         renderExtraFilters={() => (
           <>
             <KidsStats items={milestones} contacts={contacts} />
@@ -274,11 +266,11 @@ function KidsList() {
         filterValue={ratingFilter}
         onFilterChange={setRatingFilter}
         filterColor="var(--color-kids, #FF6B35)"
-        sourceFilter={sourceFilter}
-        onSourceChange={setSourceFilter}
+        sourceFilter={lf.sourceFilter}
+        onSourceChange={lf.setSourceFilter}
         avatarUrl={profile?.avatar_url}
-        sharedCount={sharedCount}
-        recommendedCount={recommendedCount}
+        sharedCount={lf.sharedCount}
+        recommendedCount={lf.recommendedCount}
       />
 
       {filtered.length === 0 && !loading && (

--- a/client/src/features/movies/components/MovieList.js
+++ b/client/src/features/movies/components/MovieList.js
@@ -1,5 +1,4 @@
 import React, { useState, useMemo, useCallback, useEffect, useRef } from "react";
-import { isMineOnly, isSharedSource } from "../../../helpers/operator";
 import { Button, Spinner } from "react-bootstrap";
 import movieSchema from "../movieSchema";
 import MovieForm from "./MovieForm";
@@ -15,13 +14,13 @@ import CategoryListHeader from "../../../components/shared/CategoryListHeader";
 import { RATING_GROUP } from "../../../components/shared/GroupedDropdownFilter";
 import SocialMemoriesCard from "../../../components/shared/SocialMemoriesCard";
 import useCategory from "../../../hooks/useCategory";
+import useListFilters from "../../../hooks/useListFilters";
 import { useAppData } from "../../../contexts/AppDataContext";
 import { searchMovies } from "../api/movieApi";
 import {
   getStatusFilterOptions,
   filterByStatus,
   getStatusLabel,
-  getInitialSourceFilter,
 } from "../../../helpers/filterUtils";
 
 const GENRE_EMOJIS = {
@@ -68,7 +67,7 @@ function MovieList() {
   } = useCategory("movies", { normalize: (data) => ({ ...data, status: data.status || "watchlist", startDate: data.startDate || "" }), schema: movieSchema });
 
   const [movieFilter, setMovieFilter] = useState("all");
-  const [sourceFilter, setSourceFilter] = useState(getInitialSourceFilter);
+  const lf = useListFilters(movies, { dateField: "startDate" });
   const { profile } = useAppData();
 
 
@@ -213,44 +212,38 @@ function MovieList() {
   }, [availableGenres, availableDecades]);
 
   const statusFiltered = filterByStatus(movies, filterStatus);
-  const sourceFiltered = sourceFilter === "mine"
-    ? statusFiltered.filter(isMineOnly)
-    : sourceFilter === "shared"
-    ? statusFiltered.filter(isSharedSource)
-    : sourceFilter === "recommended"
-    ? statusFiltered.filter((i) => i._isRecommended)
-    : statusFiltered;
+  const commonFiltered = lf.applyCommonFilters(statusFiltered);
 
   const filteredMovies = useMemo(() => {
-    if (movieFilter === "all") return sourceFiltered;
+    if (movieFilter === "all") return commonFiltered;
     const [type, val] = movieFilter.split(":");
     if (type === "genre") {
-      return sourceFiltered.filter((m) =>
+      return commonFiltered.filter((m) =>
         (m.genre || "").split(",").map((g) => g.trim()).includes(val)
       );
     }
     if (type === "decade") {
-      return sourceFiltered.filter((m) => getDecade(m.year) === val);
+      return commonFiltered.filter((m) => getDecade(m.year) === val);
     }
     if (type === "rating") {
-      return sourceFiltered.filter((m) => matchesRating(m.rating, val));
+      return commonFiltered.filter((m) => matchesRating(m.rating, val));
     }
     if (type === "ring") {
       if (val === "partner") {
-        return sourceFiltered.filter((m) => m._isShared && m._sharedByRing === 1 && parseInt(m.rating, 10) >= 4);
+        return commonFiltered.filter((m) => m._isShared && m._sharedByRing === 1 && parseInt(m.rating, 10) >= 4);
       }
       if (val === "family") {
-        return sourceFiltered.filter((m) => m._isShared && (m._sharedByRing === 2 || m._sharedByRing === 3) && parseInt(m.rating, 10) >= 4);
+        return commonFiltered.filter((m) => m._isShared && (m._sharedByRing === 2 || m._sharedByRing === 3) && parseInt(m.rating, 10) >= 4);
       }
       if (val === "friends") {
-        return sourceFiltered.filter((m) => m._isShared && m._sharedByRing === 4 && parseInt(m.rating, 10) >= 4);
+        return commonFiltered.filter((m) => m._isShared && m._sharedByRing === 4 && parseInt(m.rating, 10) >= 4);
       }
       if (val === "unwatched") {
-        return sourceFiltered.filter((m) => m._isRecommended && m.status !== "watched");
+        return commonFiltered.filter((m) => m._isRecommended && m.status !== "watched");
       }
     }
-    return sourceFiltered;
-  }, [sourceFiltered, movieFilter]);
+    return commonFiltered;
+  }, [commonFiltered, movieFilter]);
 
   const sectionTitle = `Movies - ${getStatusLabel("movies", filterStatus)}`;
   const watchedCount = movies.filter((m) => m.status === "watched").length;
@@ -269,16 +262,19 @@ function MovieList() {
         statusOptions={movieStatuses}
         filterStatus={filterStatus}
         onStatusChange={setFilterStatus}
+        yearOptions={lf.yearOptions}
+        activeYear={lf.activeYear}
+        onYearChange={lf.setActiveYear}
         renderExtraFilters={() => <MovieSocialFeed movies={movies} />}
         filterGroups={movieFilterGroups}
         filterValue={movieFilter}
         onFilterChange={setMovieFilter}
         filterColor="var(--color-movies, #E91E63)"
-        sourceFilter={sourceFilter}
-        onSourceChange={setSourceFilter}
+        sourceFilter={lf.sourceFilter}
+        onSourceChange={lf.setSourceFilter}
         avatarUrl={profile?.avatar_url}
-        sharedCount={movies.filter(isSharedSource).length}
-        recommendedCount={movies.filter((i) => i._isRecommended).length}
+        sharedCount={lf.sharedCount}
+        recommendedCount={lf.recommendedCount}
       />
 
       {/* Inline TMDB Search Bar */}

--- a/client/src/features/movies/movieSchema.js
+++ b/client/src/features/movies/movieSchema.js
@@ -1,6 +1,6 @@
 import { baseSchema } from "../../helpers/common.schema";
 import { getStatusField } from "../../helpers/statusLabels";
-import { getReflectionFields, getCompanionsField } from "../../helpers/reflection.schema";
+import { getReflectionFields, getCompanionsField, getVisibilityDefaults } from "../../helpers/reflection.schema";
 
 const movieSchema = [
   getStatusField("movies"),
@@ -81,13 +81,7 @@ const movieSchema = [
 
   // Social (Companions + Visibility + Recommend)
   getCompanionsField("watched"),
-  {
-    name: "visibilityRings",
-    type: "hidden",
-    defaultValue: [1, 2, 3, 4],
-    section: "Hidden",
-    order: 64,
-  },
+  ...getVisibilityDefaults(),
   {
     name: "visibilityControl",
     label: "🔒 Who can see this",

--- a/client/src/features/travel/components/TravelList.js
+++ b/client/src/features/travel/components/TravelList.js
@@ -14,17 +14,17 @@ import StarRating from "../../../components/shared/StarRating";
 import StatusBadge from "../../../components/shared/StatusBadge";
 import travelSchema from "../../../features/travel/travelSchema";
 import useCategory from "../../../hooks/useCategory";
+import useListFilters from "../../../hooks/useListFilters";
 import { formatDisplayDate, formatDateRange } from "../../../helpers/dateUtils";
 import { useAppData } from "../../../contexts/AppDataContext";
 import { codeToFlag, getCountryName } from "../../../data/countries";
 import dataService from "../../../services/dataService";
 import { computeTravelStats } from "../../../services/travelStats";
-import { getTripPhotos, getItemPhotos, isMineOnly, isSharedSource } from "../../../helpers/operator";
+import { getTripPhotos, getItemPhotos } from "../../../helpers/operator";
 import {
   getStatusFilterOptions,
   filterByStatus,
   getStatusLabel,
-  getInitialSourceFilter,
 } from "../../../helpers/filterUtils";
 
 function migrateMemoryToSnapshot(item) {
@@ -473,7 +473,6 @@ function TravelList() {
   const [showNextSteps, setShowNextSteps] = useState(false);
   const [linkedActivities, setLinkedActivities] = useState([]);
   const [mapPeekTrip, setMapPeekTrip] = useState(null);
-  const [sourceFilter, setSourceFilter] = useState(getInitialSourceFilter);
   const lastSavedRef = useRef(null);
 
   const {
@@ -507,17 +506,10 @@ function TravelList() {
     }
   }, [loading, travels, searchParams, setSearchParams, setViewDetailItem]);
 
+  const lf = useListFilters(travels, { dateField: "startDate" });
   const travelStatuses = getStatusFilterOptions("travel");
   const statusFiltered = filterByStatus(travels, filterStatus);
-  const filteredTravels = sourceFilter === "mine"
-    ? statusFiltered.filter(isMineOnly)
-    : sourceFilter === "shared"
-    ? statusFiltered.filter(isSharedSource)
-    : sourceFilter === "recommended"
-    ? statusFiltered.filter((i) => i._isRecommended)
-    : statusFiltered;
-  const sharedCount = travels.filter(isSharedSource).length;
-  const recommendedCount = travels.filter((i) => i._isRecommended).length;
+  const filteredTravels = lf.applyCommonFilters(statusFiltered);
   const sectionTitle = `Travel - ${getStatusLabel("travel", filterStatus)}`;
 
   const { groups, ungrouped } = groupByItinerary(filteredTravels);
@@ -640,15 +632,18 @@ function TravelList() {
         statusOptions={travelStatuses}
         filterStatus={filterStatus}
         onStatusChange={setFilterStatus}
+        yearOptions={lf.yearOptions}
+        activeYear={lf.activeYear}
+        onYearChange={lf.setActiveYear}
         tabs={VIEW_TABS}
         activeTab={activeView}
         onTabChange={setActiveView}
         tabColor="var(--color-travel)"
-        sourceFilter={sourceFilter}
-        onSourceChange={setSourceFilter}
+        sourceFilter={lf.sourceFilter}
+        onSourceChange={lf.setSourceFilter}
         avatarUrl={profile?.avatar_url}
-        sharedCount={sharedCount}
-        recommendedCount={recommendedCount}
+        sharedCount={lf.sharedCount}
+        recommendedCount={lf.recommendedCount}
       />
 
       {/* Map View */}

--- a/client/src/features/travel/travelSchema.js
+++ b/client/src/features/travel/travelSchema.js
@@ -1,6 +1,6 @@
 import { baseSchema } from "../../helpers/common.schema";
 import { getStatusField } from "../../helpers/statusLabels";
-import { getReflectionFields, getCompanionsField } from "../../helpers/reflection.schema";
+import { getReflectionFields, getCompanionsField, getVisibilityDefaults } from "../../helpers/reflection.schema";
 import { getLocationFields } from "../../helpers/location.schema";
 
 const travelFields = [
@@ -88,6 +88,7 @@ const travelFields = [
 
   // ── Social (Companions + Visibility + Recommend) ───────────────────────────
   getCompanionsField("visited"),
+  ...getVisibilityDefaults(),
   {
     name: "visibilityControl",
     label: "🔒 Who can see this",

--- a/client/src/helpers/filterUtils.js
+++ b/client/src/helpers/filterUtils.js
@@ -32,3 +32,47 @@ export function getInitialSourceFilter() {
   const source = new URLSearchParams(window.location.search).get("source");
   return ["mine", "shared", "recommended"].includes(source) ? source : "all";
 }
+
+const DEFAULT_DATE_FIELDS = ["startDate", "createdAt"];
+
+/**
+ * Resolves a date string from an item given a dateField spec, which may be a
+ * function, a single field name, or an ordered list of fallback field names.
+ */
+function getItemDateValue(item, dateField = DEFAULT_DATE_FIELDS) {
+  if (typeof dateField === "function") return dateField(item);
+  const fields = Array.isArray(dateField) ? dateField : [dateField];
+  for (const f of fields) {
+    if (item[f]) return item[f];
+  }
+  return "";
+}
+
+/** Extracts a 4-digit year from a date string (date-only or full ISO timestamp). */
+function yearOf(value) {
+  if (!value) return NaN;
+  const s = String(value);
+  const dt = s.length <= 10 ? new Date(s + "T00:00:00") : new Date(s);
+  return dt.getFullYear();
+}
+
+/**
+ * Returns the distinct years present across items (newest first) for the Year
+ * filter pills. Shared so every page derives its year list identically.
+ */
+export function getYearOptions(items, dateField = DEFAULT_DATE_FIELDS) {
+  const years = new Set();
+  (items || []).forEach((item) => {
+    const y = yearOf(getItemDateValue(item, dateField));
+    if (!isNaN(y)) years.add(y);
+  });
+  return [...years].sort((a, b) => b - a);
+}
+
+/** Filters items to a single year ("all" passes everything through). */
+export function filterByYear(items, year, dateField = DEFAULT_DATE_FIELDS) {
+  if (!year || year === "all") return items;
+  return items.filter(
+    (item) => String(yearOf(getItemDateValue(item, dateField))) === String(year)
+  );
+}

--- a/client/src/helpers/operator.js
+++ b/client/src/helpers/operator.js
@@ -91,11 +91,28 @@ export const getItemPhotos = (item) =>
  * pills. An item belongs to "Shared" if it was either received from someone else
  * (_isShared) or the owner has shared it outward with a collaborator, pending or
  * accepted (_hasOutgoingShares). "Mine" is the complement: owned and unshared.
+ *
+ * This is the single source of truth for source classification across every page
+ * (category lists, Timeline, My Memories, Shared, Recommendations). Do NOT use
+ * isEntryShared (PrivacyIndicator) for source filtering — that one keys on
+ * visibility/ring fields and is for the lock badge only.
  */
 export const isSharedSource = (item) =>
   !!(item._isShared || item._hasOutgoingShares);
 
 export const isMineOnly = (item) => !isSharedSource(item);
+
+/**
+ * Applies the "All | Mine | Shared | Recommended" source filter to a list using
+ * the canonical classifier above. Centralized so the meaning of each tab stays
+ * consistent everywhere instead of being re-implemented per page.
+ */
+export const applySourceFilter = (items, source) => {
+  if (source === "mine") return items.filter(isMineOnly);
+  if (source === "shared") return items.filter(isSharedSource);
+  if (source === "recommended") return items.filter((i) => i._isRecommended);
+  return items;
+};
 
 /**
  * Returns the owner's photos and each companion's overlay photos separately.

--- a/client/src/helpers/reflection.schema.js
+++ b/client/src/helpers/reflection.schema.js
@@ -59,6 +59,35 @@ export function getReflectionFields(experiencedStatus) {
 }
 
 /**
+ * Hidden state behind the "Who can see this" (visible-to) control.
+ *
+ * `visibilityRings` defaults to all four rings ("Everyone") so a new entry is
+ * shared with the user's whole network unless they narrow it. `visibilityContacts`
+ * holds individuals added directly (e.g. auto-added when collaborating) so they
+ * can be removed independently of any ring.
+ *
+ * Spread into a schema alongside its `visible-to` field.
+ */
+export function getVisibilityDefaults() {
+  return [
+    {
+      name: "visibilityRings",
+      type: "hidden",
+      defaultValue: [1, 2, 3, 4],
+      section: "Hidden",
+      order: 64,
+    },
+    {
+      name: "visibilityContacts",
+      type: "hidden",
+      defaultValue: [],
+      section: "Hidden",
+      order: 64,
+    },
+  ];
+}
+
+/**
  * Companions field for the Social section. Separated from getReflectionFields
  * so it can be grouped with visibility and recommendation controls.
  */

--- a/client/src/helpers/visibilitySharing.js
+++ b/client/src/helpers/visibilitySharing.js
@@ -1,0 +1,65 @@
+import { RING_LEVELS } from "./ringMeta";
+
+/**
+ * Cross-field rules linking "Who can see this" (visibilityRings +
+ * visibilityContacts) with the "Share & Collaborate" toggle
+ * (shareWithCompanionIds). Kept as pure functions over a formData object so the
+ * logic is testable and the components stay thin.
+ *
+ * Invariant: collaborate ⟹ visible.
+ *  - Enabling collaborate for someone adds them to "Who can see this".
+ *  - Disabling collaborate leaves them visible (user removes manually).
+ *  - Removing someone from "Who can see this" also stops collaborating with them
+ *    (you can't collaborate on something they can't see).
+ *  - "Who was there" (companions) is independent and never touched here.
+ */
+
+const uniq = (arr) => Array.from(new Set(arr));
+
+/** Add a contact to "Who can see this" (idempotent). */
+export function addVisibilityContact(formData, contactId) {
+  const current = formData.visibilityContacts || [];
+  if (current.includes(contactId)) return formData;
+  return { ...formData, visibilityContacts: [...current, contactId] };
+}
+
+/**
+ * Remove a contact from "Who can see this". Also drops any active collaborate
+ * share with them — they can't collaborate on an entry they can't see.
+ */
+export function removeVisibilityContact(formData, contactId) {
+  return {
+    ...formData,
+    visibilityContacts: (formData.visibilityContacts || []).filter((id) => id !== contactId),
+    shareWithCompanionIds: (formData.shareWithCompanionIds || []).filter((id) => id !== contactId),
+  };
+}
+
+/**
+ * Apply a new "Share & Collaborate" selection. Newly enabled collaborators are
+ * auto-added to "Who can see this"; disabling a collaborator does not remove
+ * their visibility (collaborate ⟹ visible, but not the reverse).
+ */
+export function applyCollaborateChange(formData, nextShareIds) {
+  const prevShareIds = formData.shareWithCompanionIds || [];
+  const added = nextShareIds.filter((id) => !prevShareIds.includes(id));
+  return {
+    ...formData,
+    shareWithCompanionIds: nextShareIds,
+    visibilityContacts: uniq([...(formData.visibilityContacts || []), ...added]),
+  };
+}
+
+/** True when every ring is selected — i.e. "Everyone" in the user's network. */
+export function isEveryone(visibilityRings) {
+  const set = new Set(visibilityRings || []);
+  return RING_LEVELS.every((level) => set.has(level));
+}
+
+/** Toggle the "Everyone" shortcut: select all rings, or clear them all. */
+export function toggleEveryone(formData) {
+  return {
+    ...formData,
+    visibilityRings: isEveryone(formData.visibilityRings) ? [] : [...RING_LEVELS],
+  };
+}

--- a/client/src/helpers/visibilitySharing.test.js
+++ b/client/src/helpers/visibilitySharing.test.js
@@ -1,0 +1,60 @@
+import {
+  addVisibilityContact,
+  removeVisibilityContact,
+  applyCollaborateChange,
+  isEveryone,
+  toggleEveryone,
+} from "./visibilitySharing";
+
+describe("visibilitySharing — collaborate ⟹ visible (#6)", () => {
+  test("enabling collaborate adds the person to Who can see this", () => {
+    const before = { shareWithCompanionIds: [], visibilityContacts: [] };
+    const after = applyCollaborateChange(before, ["c1"]);
+    expect(after.shareWithCompanionIds).toEqual(["c1"]);
+    expect(after.visibilityContacts).toContain("c1");
+  });
+
+  test("disabling collaborate leaves them visible (manual removal)", () => {
+    const before = { shareWithCompanionIds: ["c1"], visibilityContacts: ["c1"] };
+    const after = applyCollaborateChange(before, []);
+    expect(after.shareWithCompanionIds).toEqual([]);
+    expect(after.visibilityContacts).toEqual(["c1"]); // still visible
+  });
+
+  test("removing from Who can see this also turns collaborate off", () => {
+    const before = { shareWithCompanionIds: ["c1", "c2"], visibilityContacts: ["c1", "c2"] };
+    const after = removeVisibilityContact(before, "c1");
+    expect(after.visibilityContacts).toEqual(["c2"]);
+    expect(after.shareWithCompanionIds).toEqual(["c2"]); // c1 collaborate dropped
+  });
+
+  test("enabling collaborate does not duplicate an already-visible contact", () => {
+    const before = { shareWithCompanionIds: [], visibilityContacts: ["c1"] };
+    const after = applyCollaborateChange(before, ["c1"]);
+    expect(after.visibilityContacts).toEqual(["c1"]);
+  });
+
+  test("addVisibilityContact is idempotent and does not touch sharing", () => {
+    const before = { visibilityContacts: ["c1"], shareWithCompanionIds: [] };
+    expect(addVisibilityContact(before, "c1")).toBe(before);
+    const after = addVisibilityContact(before, "c2");
+    expect(after.visibilityContacts).toEqual(["c1", "c2"]);
+    expect(after.shareWithCompanionIds).toEqual([]);
+  });
+});
+
+describe("visibilitySharing — Everyone (#7)", () => {
+  test("isEveryone is true only when all rings are selected", () => {
+    expect(isEveryone([1, 2, 3, 4])).toBe(true);
+    expect(isEveryone([1, 2, 3])).toBe(false);
+    expect(isEveryone([])).toBe(false);
+  });
+
+  test("toggleEveryone selects all rings when not everyone", () => {
+    expect(toggleEveryone({ visibilityRings: [1] }).visibilityRings).toEqual([1, 2, 3, 4]);
+  });
+
+  test("toggleEveryone clears all rings when already everyone", () => {
+    expect(toggleEveryone({ visibilityRings: [1, 2, 3, 4] }).visibilityRings).toEqual([]);
+  });
+});

--- a/client/src/hooks/useCategory.js
+++ b/client/src/hooks/useCategory.js
@@ -266,7 +266,16 @@ export default function useCategory(category, { migrate, normalize, schema } = {
             const collaboratorStatuses = Object.fromEntries(
               shared.map((c) => [c.collaborator_contact_id, c.status])
             );
-            setFormData((prev) => ({ ...prev, shareWithCompanionIds: sharedContactIds, _collaboratorStatuses: collaboratorStatuses }));
+            setFormData((prev) => ({
+              ...prev,
+              shareWithCompanionIds: sharedContactIds,
+              // collaborate ⟹ visible: existing collaborators must show under
+              // "Who can see this" even on legacy entries saved before this field.
+              visibilityContacts: Array.from(
+                new Set([...(prev.visibilityContacts || []), ...sharedContactIds])
+              ),
+              _collaboratorStatuses: collaboratorStatuses,
+            }));
           }
         } catch {}
       }

--- a/client/src/hooks/useListFilters.js
+++ b/client/src/hooks/useListFilters.js
@@ -1,0 +1,58 @@
+import { useState, useMemo, useCallback } from "react";
+import { isSharedSource, applySourceFilter } from "../helpers/operator";
+import {
+  getInitialSourceFilter,
+  getYearOptions,
+  filterByYear,
+} from "../helpers/filterUtils";
+
+/**
+ * Shared list-filter state for the standard header stack. Owns the two filter
+ * dimensions every page has in common — Year and Source (Mine/Shared/Recommended)
+ * — so individual list components no longer re-implement them. Status filtering
+ * stays in useCategory; category-specific pills stay local to each list.
+ *
+ * Usage:
+ *   const lf = useListFilters(items);
+ *   const statusFiltered = filterByStatus(items, filterStatus);
+ *   const commonFiltered = lf.applyCommonFilters(statusFiltered);
+ *   // then apply the page's bespoke category filter on top of commonFiltered
+ *
+ * @param {object[]} items - the full (unfiltered) item list for the category
+ * @param {object} [opts]
+ * @param {string|string[]|function} [opts.dateField] - how to read each item's date
+ */
+export default function useListFilters(items, { dateField } = {}) {
+  const [activeYear, setActiveYear] = useState("all");
+  const [sourceFilter, setSourceFilter] = useState(getInitialSourceFilter);
+
+  const yearOptions = useMemo(
+    () => getYearOptions(items, dateField),
+    [items, dateField]
+  );
+
+  const sharedCount = useMemo(
+    () => items.filter(isSharedSource).length,
+    [items]
+  );
+  const recommendedCount = useMemo(
+    () => items.filter((i) => i._isRecommended).length,
+    [items]
+  );
+
+  const applyCommonFilters = useCallback(
+    (list) => filterByYear(applySourceFilter(list, sourceFilter), activeYear, dateField),
+    [sourceFilter, activeYear, dateField]
+  );
+
+  return {
+    activeYear,
+    setActiveYear,
+    yearOptions,
+    sourceFilter,
+    setSourceFilter,
+    sharedCount,
+    recommendedCount,
+    applyCommonFilters,
+  };
+}

--- a/client/src/pages/Recommendations.js
+++ b/client/src/pages/Recommendations.js
@@ -8,6 +8,13 @@ import dataService from "../services/dataService";
 import { getCategoryMeta } from "../helpers/categoryMeta";
 import statusLabels from "../helpers/statusLabels";
 import { findMatchingOwnedItem, mergeRecommender } from "../helpers/recommendationMatcher";
+import YearFilter from "../components/shared/YearFilter";
+import GroupedDropdownFilter from "../components/shared/GroupedDropdownFilter";
+import { getYearOptions, filterByYear } from "../helpers/filterUtils";
+
+// Year/category derive from the recommended entry's date (falling back to when
+// the recommendation arrived) so the filters read like the My Memories page.
+const recDate = (r) => r.entry?.startDate || r.created_at || "";
 
 // Recommendation rows use active/accepted/dismissed; the UI presents these with
 // the same Pending/Accepted/Declined vocabulary as the Shared Experiences feed.
@@ -19,6 +26,7 @@ function Recommendations() {
   const [loading, setLoading] = useState(true);
   const [statusFilter, setStatusFilter] = useState("pending");
   const [categoryFilter, setCategoryFilter] = useState("all");
+  const [activeYear, setActiveYear] = useState("all");
 
   useEffect(() => {
     load();
@@ -152,9 +160,20 @@ function Recommendations() {
     : enriched.filter((r) => r.status === TAB_TO_STATUS[statusFilter]);
 
   const categories = [...new Set(enriched.map((r) => r.category))];
-  const filtered = categoryFilter === "all"
+  const categoryFilterGroups = [{
+    key: "category",
+    label: "\u{1F4C2} Category",
+    options: categories.map((cat) => ({
+      value: cat,
+      label: `${getCategoryMeta(cat).icon} ${cat.charAt(0).toUpperCase() + cat.slice(1)}`,
+    })),
+  }];
+  const yearOptions = getYearOptions(enriched, recDate);
+
+  const categoryFiltered = categoryFilter === "all"
     ? statusFiltered
     : statusFiltered.filter((r) => r.category === categoryFilter);
+  const filtered = filterByYear(categoryFiltered, activeYear, recDate);
 
   if (loading) {
     return (
@@ -196,28 +215,17 @@ function Recommendations() {
         </div>
       </div>
 
-      {/* Category filter */}
+      {/* Year filter (renders only when 2+ years exist) */}
+      <YearFilter years={yearOptions} value={activeYear} onChange={setActiveYear} />
+
+      {/* Category filter — single pill, matching the category pages */}
       {categories.length > 1 && (
-        <div className="d-flex gap-2 mb-3 flex-wrap">
-          <button
-            className={`btn btn-sm ${categoryFilter === "all" ? "btn-primary" : "btn-outline-secondary"}`}
-            onClick={() => setCategoryFilter("all")}
-          >
-            All
-          </button>
-          {categories.map((cat) => {
-            const meta = getCategoryMeta(cat);
-            return (
-              <button
-                key={cat}
-                className={`btn btn-sm ${categoryFilter === cat ? "btn-primary" : "btn-outline-secondary"}`}
-                onClick={() => setCategoryFilter(cat)}
-              >
-                {meta.icon} {cat.charAt(0).toUpperCase() + cat.slice(1)}
-              </button>
-            );
-          })}
-        </div>
+        <GroupedDropdownFilter
+          groups={categoryFilterGroups}
+          value={categoryFilter}
+          onChange={setCategoryFilter}
+          color="var(--color-primary)"
+        />
       )}
 
       {filtered.length === 0 ? (

--- a/client/src/pages/SharedFeed.js
+++ b/client/src/pages/SharedFeed.js
@@ -6,9 +6,12 @@ import overlayService from "../services/overlayService";
 import SharedMemoriesSection from "../components/shared/SharedMemoriesSection";
 import { useAppData } from "../contexts/AppDataContext";
 import { useSocialData } from "../contexts/SocialDataContext";
-import categoryMeta, { getEntryTitle, getEntrySubtitle } from "../helpers/categoryMeta";
+import categoryMeta, { getEntryTitle, getEntrySubtitle, getCategoryMeta } from "../helpers/categoryMeta";
 import { formatDateRange } from "../helpers/dateUtils";
 import StarRating from "../components/shared/StarRating";
+import YearFilter from "../components/shared/YearFilter";
+import GroupedDropdownFilter from "../components/shared/GroupedDropdownFilter";
+import { getYearOptions, filterByYear } from "../helpers/filterUtils";
 
 // ── Shared Entry Card ─────────────────────────────────────────────────────────
 
@@ -308,6 +311,8 @@ function SharedFeed() {
   const [myOverlays, setMyOverlays] = useState({});
   const [loading, setLoading] = useState(true);
   const [filterStatus, setFilterStatus] = useState("pending");
+  const [categoryFilter, setCategoryFilter] = useState("all");
+  const [activeYear, setActiveYear] = useState("all");
   const [overlayTarget, setOverlayTarget] = useState(null);
   const [editTarget, setEditTarget] = useState(null);
 
@@ -369,10 +374,26 @@ function SharedFeed() {
         id: collab.entry_id,
       }));
 
-  const filteredEntries = sharedEntries.filter((item) => {
-    if (filterStatus !== "all" && item._collabStatus !== filterStatus) return false;
-    return true;
-  });
+  const categories = [...new Set(sharedEntries.map((e) => e._category).filter(Boolean))];
+  const categoryFilterGroups = [{
+    key: "category",
+    label: "\u{1F4C2} Category",
+    options: categories.map((cat) => ({
+      value: cat,
+      label: `${getCategoryMeta(cat).icon} ${cat.charAt(0).toUpperCase() + cat.slice(1)}`,
+    })),
+  }];
+  const yearOptions = getYearOptions(sharedEntries, ["startDate", "createdAt"]);
+
+  const filteredEntries = filterByYear(
+    sharedEntries.filter((item) => {
+      if (filterStatus !== "all" && item._collabStatus !== filterStatus) return false;
+      if (categoryFilter !== "all" && item._category !== categoryFilter) return false;
+      return true;
+    }),
+    activeYear,
+    ["startDate", "createdAt"]
+  );
 
   const handleAccept = async (item) => {
     await collaboratorService.acceptCollaboration(item._collabId);
@@ -473,6 +494,19 @@ function SharedFeed() {
           </div>
         </div>
       </div>
+
+      {/* Year filter (renders only when 2+ years exist) */}
+      <YearFilter years={yearOptions} value={activeYear} onChange={setActiveYear} />
+
+      {/* Category filter — single pill, matching the category pages */}
+      {categories.length > 1 && (
+        <GroupedDropdownFilter
+          groups={categoryFilterGroups}
+          value={categoryFilter}
+          onChange={setCategoryFilter}
+          color="var(--color-primary)"
+        />
+      )}
 
       {loading ? (
         <div style={{ textAlign: "center", padding: "3rem", color: "var(--color-text-tertiary)" }}>Loading…</div>

--- a/client/src/pages/Snaps.js
+++ b/client/src/pages/Snaps.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import categoryMeta from "../helpers/categoryMeta";
 import { formatDisplayDate } from "../helpers/dateUtils";
-import { getAllSnapshots, getItemPhotos } from "../helpers/operator";
+import { getAllSnapshots, getItemPhotos, isSharedSource } from "../helpers/operator";
 import {
   enrichItemsWithSocialContent,
   getAllSocialSnaps,
@@ -11,7 +11,8 @@ import {
 import dataService from "../services/dataService";
 import SourceFilterPills from "../components/shared/SourceFilterPills";
 import StatsStrip from "../components/shared/StatsStrip";
-import { isEntryShared } from "../components/shared/PrivacyIndicator";
+import YearFilter from "../components/shared/YearFilter";
+import { getYearOptions, filterByYear } from "../helpers/filterUtils";
 import EntryDetailPanel from "../components/shared/EntryDetailPanel";
 import { useAppData } from "../contexts/AppDataContext";
 import { SCHEMA_MAP, CATEGORY_KEYS } from "../helpers/schemaRegistry";
@@ -30,6 +31,7 @@ const VIEW_TABS = [
 function Snaps() {
   const [activeView, setActiveView] = useState("all");
   const [activeCategory, setActiveCategory] = useState("all");
+  const [activeYear, setActiveYear] = useState("all");
   const [sourceFilter, setSourceFilter] = useState("all");
   const [allSnaps, setAllSnaps] = useState([]);
   const [allPhotos, setAllPhotos] = useState([]);
@@ -72,7 +74,7 @@ function Snaps() {
                 icon: meta.icon,
                 color: meta.color,
                 date,
-                isShared: isEntryShared(item),
+                isShared: isSharedSource(item),
                 rawItem: item,
                 key: `${cat.key}-snap-${item.id || title}-${i}`,
               });
@@ -109,7 +111,7 @@ function Snaps() {
                 icon: meta.icon,
                 color: meta.color,
                 date,
-                isShared: isEntryShared(item),
+                isShared: isSharedSource(item),
                 rawItem: item,
                 key: `${cat.key}-photo-${item.id || title}-${i}`,
               });
@@ -159,12 +161,18 @@ function Snaps() {
     return items;
   };
 
+  const filterByYearLocal = (items) => filterByYear(items, activeYear, "date");
+
   const sortByDate = (items) =>
     [...items].sort((a, b) => b.date.localeCompare(a.date));
 
-  const filteredSnaps = sortByDate(filterBySource(filterByCategory(allSnaps)));
-  const filteredPhotos = sortByDate(filterBySource(filterByCategory(allPhotos)));
-  const filteredAll = sortByDate(filterBySource(filterByCategory([...allSnaps, ...allPhotos])));
+  const applyFilters = (items) =>
+    sortByDate(filterBySource(filterByYearLocal(filterByCategory(items))));
+
+  const yearOptions = getYearOptions([...allSnaps, ...allPhotos], "date");
+  const filteredSnaps = applyFilters(allSnaps);
+  const filteredPhotos = applyFilters(allPhotos);
+  const filteredAll = applyFilters([...allSnaps, ...allPhotos]);
 
   const visibleItems =
     activeView === "snaps" ? filteredSnaps :
@@ -196,29 +204,8 @@ function Snaps() {
         ]} />
       )}
 
-      {/* View tabs: All / Snaps / Photos */}
-      <div className="d-flex gap-2 mb-3">
-        {VIEW_TABS.map((tab) => (
-          <button
-            key={tab.id}
-            type="button"
-            onClick={() => setActiveView(tab.id)}
-            style={{
-              padding: "0.3rem 0.9rem",
-              borderRadius: "20px",
-              border: "2px solid var(--color-primary)",
-              background: activeView === tab.id ? "var(--color-primary)" : "transparent",
-              color: activeView === tab.id ? "#fff" : "var(--color-primary)",
-              fontWeight: 600,
-              fontSize: "var(--font-size-sm)",
-              cursor: "pointer",
-              transition: "all 0.15s",
-            }}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </div>
+      {/* Year filter (renders only when 2+ years exist) */}
+      <YearFilter years={yearOptions} value={activeYear} onChange={setActiveYear} />
 
       {/* Category filter pills */}
       {categoriesWithContent.length > 1 && (
@@ -243,6 +230,30 @@ function Snaps() {
           })}
         </div>
       )}
+
+      {/* View tabs: All / Snaps / Photos */}
+      <div className="d-flex gap-2 mb-3">
+        {VIEW_TABS.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => setActiveView(tab.id)}
+            style={{
+              padding: "0.3rem 0.9rem",
+              borderRadius: "20px",
+              border: "2px solid var(--color-primary)",
+              background: activeView === tab.id ? "var(--color-primary)" : "transparent",
+              color: activeView === tab.id ? "#fff" : "var(--color-primary)",
+              fontWeight: 600,
+              fontSize: "var(--font-size-sm)",
+              cursor: "pointer",
+              transition: "all 0.15s",
+            }}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
 
       <SourceFilterPills
         value={sourceFilter}

--- a/client/src/pages/Timeline.js
+++ b/client/src/pages/Timeline.js
@@ -3,12 +3,13 @@ import { Link } from "react-router-dom";
 import categoryMeta from "../helpers/categoryMeta";
 import { formatDisplayDate } from "../helpers/dateUtils";
 import StatusBadge from "../components/shared/StatusBadge";
-import { getSnapshotTeaser } from "../helpers/operator";
+import { getSnapshotTeaser, isSharedSource } from "../helpers/operator";
 import dataService from "../services/dataService";
-import PrivacyIndicator, { isEntryShared } from "../components/shared/PrivacyIndicator";
+import PrivacyIndicator from "../components/shared/PrivacyIndicator";
 import SourceFilterPills from "../components/shared/SourceFilterPills";
 import EntryDetailPanel from "../components/shared/EntryDetailPanel";
 import StatsStrip from "../components/shared/StatsStrip";
+import YearFilter from "../components/shared/YearFilter";
 import { useAppData } from "../contexts/AppDataContext";
 import { SCHEMA_MAP, CATEGORY_KEYS } from "../helpers/schemaRegistry";
 import { enrichItemsWithSocialContent, getSocialPreview } from "../helpers/socialContent";
@@ -69,7 +70,7 @@ function Timeline() {
               country: item.country,
               date,
               isWishlist: item.status === "wishlist",
-              isShared: isEntryShared(item),
+              isShared: isSharedSource(item),
               rawItem: item,
               snapshot: getSnapshotTeaser(item),
               socialPreview: getSocialPreview(item),
@@ -166,32 +167,12 @@ function Timeline() {
         return <StatsStrip stats={stats} />;
       })()}
 
-      {/* Year pills */}
-      {years.length > 0 && (
-        <div className="status-toggle mb-2">
-          <button
-            className={`btn ${activeYear === "all" ? "active" : ""}`}
-            onClick={() => { setActiveYear("all"); setActiveMonth("all"); }}
-          >
-            All
-          </button>
-          {years.map((year) => {
-            const count = allEntries.filter(
-              (e) => String(new Date(e.date + "T00:00:00").getFullYear()) === String(year)
-            ).length;
-            return (
-              <button
-                key={year}
-                className={`btn ${activeYear === String(year) ? "active" : ""}`}
-                onClick={() => { setActiveYear(String(year)); setActiveMonth("all"); }}
-              >
-                {year}
-                <span className="ms-1 opacity-75">({count})</span>
-              </button>
-            );
-          })}
-        </div>
-      )}
+      {/* Year filter (shared component; renders only when 2+ years exist) */}
+      <YearFilter
+        years={years}
+        value={activeYear}
+        onChange={(y) => { setActiveYear(y); setActiveMonth("all"); }}
+      />
 
       {/* Month sub-pills (only when a year is selected) */}
       {activeYear !== "all" && monthsWithData.length > 0 && (


### PR DESCRIPTION
## Summary

Unifies the filter/header stack across every page and fixes a split-brain "shared" definition that leaked collaboration-flagged items into **Mine**.

### The bug (Aspen with Madison)
Category pages classified source with `isSharedSource` (collaboration flags: `_isShared || _hasOutgoingShares`) while **Timeline** and **My Memories** used `isEntryShared` (JSONB visibility fields), which ignored `_hasOutgoingShares`. So an owner's collaboration-flagged entries appeared under **Mine** and were duplicated under **Shared**.

**Fix:** `isSharedSource` is now the single source classifier everywhere (new `applySourceFilter` in `operator.js`). `isEntryShared` is demoted to the privacy lock-badge only. Collaboration-flagged items (pending *or* accepted) now appear only under **Shared**.

## Changes

**Foundation (scale play)**
- New [`useListFilters`](client/src/hooks/useListFilters.js) hook centralizes Year + Source filtering and counts — all 8 category lists route through it instead of re-implementing the source ternary.
- New shared [`YearFilter`](client/src/components/shared/YearFilter.js) (hidden under 2 years) + `getYearOptions`/`filterByYear` helpers in `filterUtils.js`.
- [`CategoryListHeader`](client/src/components/shared/CategoryListHeader.js) gains a Year slot; view-toggle tabs moved below the category pills to match the standard hierarchy: **Stats → Status → Year → Category pills → View toggle → Source**.

**Pills standardized to Movie UX**
- Activities: 5 pills → one **Type** pill.
- Cellar: Wine/Whiskey **tabs** → single-select **Type** pill (+ sub-type/varietal/rating).

**Consistency + shared pages**
- StatsStrip link → **"Full Stats →"** (only the 4 categories with real stats routes link).
- SharedFeed & Recommendations gain **Year + single category-pill** filters alongside status tabs; Snaps gains a Year filter.

## Verification
- ✅ `npx react-scripts build` clean
- ✅ 130/130 tests pass (`node scripts/tests/run-all.mjs`)
- ✅ Source-filter + year-helper logic verified against the real modules
- ✅ Login page renders with zero console errors
- ⚠️ Authenticated in-browser walkthrough of the live Aspen trip not run (app is login-gated) — proven at the logic layer; worth an eyeball before merge.

## Note
Cellar shows Wine-Type / Varietal / Whiskey-Type pills together (single-select, like Movies' genre/decade/rating) rather than contextually by type — easy to switch to contextual if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)