### PR TITLE
fix: filter parity — missed requirements, multi-pill filters, source bug

### DIFF
--- a/client/src/components/shared/DoneWishlistFilter.js
+++ b/client/src/components/shared/DoneWishlistFilter.js
@@ -1,0 +1,43 @@
+import React from "react";
+
+/**
+ * Unified status filter for mixed-category pages (Timeline, My Memories) where
+ * each category's "realized" state has a different label (visited/attended/
+ * watched/owned/tried/done). Collapses them to the common pair Done vs Wishlist:
+ *   - "wishlist"  → status === "wishlist"
+ *   - "done"      → anything else (the realized state)
+ *
+ * Reuses the `.status-toggle` pill styling; data-status drives the accent color
+ * (done = the realized/"attended" color, wishlist = the wishlist color).
+ */
+const OPTIONS = [
+  { id: "all", label: "All" },
+  { id: "done", label: "Done" },
+  { id: "wishlist", label: "Wishlist" },
+];
+
+export function matchesDoneWishlist(status, filter) {
+  if (filter === "all") return true;
+  if (filter === "wishlist") return status === "wishlist";
+  return status !== "wishlist"; // "done"
+}
+
+function DoneWishlistFilter({ value, onChange }) {
+  return (
+    <div className="status-toggle mb-3" role="group" aria-label="Status filter">
+      {OPTIONS.map((opt) => (
+        <button
+          key={opt.id}
+          type="button"
+          className={`btn btn-sm ${value === opt.id ? "active" : ""}`}
+          data-status={opt.id === "all" ? undefined : opt.id === "wishlist" ? "wishlist" : "attended"}
+          onClick={() => onChange(opt.id)}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default DoneWishlistFilter;

--- a/client/src/components/shared/GroupedDropdownFilter.js
+++ b/client/src/components/shared/GroupedDropdownFilter.js
@@ -13,6 +13,25 @@ export const RATING_GROUP = {
   options: RATING_OPTIONS,
 };
 
+// Plain-valued rating options for MultiPillFilter (independent per-pill value,
+// not the "rating:" prefixed single-select values above).
+export const RATING_PILL_OPTIONS = [
+  { value: "5", label: "★★★★★" },
+  { value: "4+", label: "★★★★☆+" },
+  { value: "3+", label: "★★★☆☆+" },
+  { value: "unrated", label: "No rating" },
+];
+
+/** Shared rating matcher for the plain values above ("5" | "4+" | "3+" | "unrated"). */
+export function matchesRatingValue(rating, val) {
+  const r = parseInt(rating, 10);
+  if (val === "unrated") return !r;
+  if (val === "5") return r === 5;
+  if (val === "4+") return r >= 4;
+  if (val === "3+") return r >= 3;
+  return true;
+}
+
 /**
  * Reusable grouped dropdown filter with pill buttons that expand sub-option menus.
  *

--- a/client/src/components/shared/MultiPillFilter.js
+++ b/client/src/components/shared/MultiPillFilter.js
@@ -1,0 +1,152 @@
+import React, { useState, useRef, useEffect, useCallback } from "react";
+
+/**
+ * Multi-dimensional pill filter. Unlike GroupedDropdownFilter (one active value
+ * across the whole row), every pill here holds its OWN value and selections
+ * stack — e.g. Wine + Red + 4★ at once. Pills can also be contextual: a pill is
+ * hidden unless its optional `visibleWhen(values)` returns true.
+ *
+ * Props:
+ * - pills: [{
+ *     key,                 // unique id, also the key in the `values` map
+ *     label,               // pill button text
+ *     options: [{ value, label }],
+ *     value,               // this pill's current value ("all" = unset)
+ *     onChange(value),     // called when the user picks an option / clears
+ *     allLabel,            // optional reset-option label (default derived from label)
+ *     color,               // optional accent (falls back to `color` prop)
+ *     visibleWhen(values), // optional; values = { [key]: value } for all pills
+ *   }]
+ * - color: default accent color for pills
+ */
+export default function MultiPillFilter({ pills, color = "var(--color-primary)" }) {
+  const [openKey, setOpenKey] = useState(null);
+  const containerRef = useRef(null);
+  const leaveTimerRef = useRef(null);
+
+  useEffect(() => {
+    function handleClickOutside(e) {
+      if (containerRef.current && !containerRef.current.contains(e.target)) {
+        setOpenKey(null);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  useEffect(() => () => clearTimeout(leaveTimerRef.current), []);
+
+  const handleMouseEnter = useCallback((key) => {
+    clearTimeout(leaveTimerRef.current);
+    setOpenKey(key);
+  }, []);
+
+  const handleMouseLeave = useCallback((key) => {
+    leaveTimerRef.current = setTimeout(() => {
+      setOpenKey((current) => (current === key ? null : current));
+    }, 150);
+  }, []);
+
+  const values = Object.fromEntries(pills.map((p) => [p.key, p.value]));
+  const visiblePills = pills.filter((p) => (p.visibleWhen ? p.visibleWhen(values) : true));
+
+  return (
+    <div
+      ref={containerRef}
+      className="d-flex gap-2 flex-wrap mb-3"
+      style={{ position: "relative" }}
+    >
+      {visiblePills.map((pill) => {
+        const accent = pill.color || color;
+        const isActive = pill.value && pill.value !== "all";
+        const resetLabel = pill.allLabel || `All ${pill.label.replace(/^[^\w]*/, "").trim()}`;
+
+        return (
+          <div
+            key={pill.key}
+            style={{ display: "inline-block", position: "relative" }}
+            onMouseEnter={() => handleMouseEnter(pill.key)}
+            onMouseLeave={() => handleMouseLeave(pill.key)}
+          >
+            <button
+              type="button"
+              onClick={() => setOpenKey(openKey === pill.key ? null : pill.key)}
+              style={{
+                padding: "0.3rem 0.75rem",
+                borderRadius: "20px",
+                border: `2px solid ${accent}`,
+                background: isActive ? accent : "transparent",
+                color: isActive ? "#fff" : accent,
+                fontWeight: 600,
+                fontSize: "var(--font-size-sm)",
+                cursor: "pointer",
+              }}
+            >
+              {pill.label}
+            </button>
+
+            {openKey === pill.key && (
+              <div style={{ position: "absolute", top: "100%", left: 0, zIndex: 100, paddingTop: 4 }}>
+                <div
+                  style={{
+                    background: "var(--color-surface)",
+                    border: "1px solid var(--color-border)",
+                    borderRadius: "var(--card-radius)",
+                    padding: "0.5rem",
+                    boxShadow: "var(--card-shadow-hover)",
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: "0.25rem",
+                    minWidth: 160,
+                  }}
+                >
+                  <button
+                    type="button"
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => { pill.onChange("all"); setOpenKey(null); }}
+                    style={{
+                      textAlign: "left",
+                      padding: "0.3rem 0.5rem",
+                      border: "none",
+                      background: !isActive ? "var(--color-surface-hover)" : "none",
+                      borderRadius: 4,
+                      cursor: "pointer",
+                      fontSize: "var(--font-size-sm)",
+                      fontWeight: !isActive ? 700 : 400,
+                      color: "var(--color-text-secondary)",
+                      borderBottom: "1px solid var(--color-border)",
+                      marginBottom: "0.25rem",
+                      paddingBottom: "0.4rem",
+                    }}
+                  >
+                    {resetLabel}
+                  </button>
+                  {pill.options.map((opt) => (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() => { pill.onChange(opt.value); setOpenKey(null); }}
+                      style={{
+                        textAlign: "left",
+                        padding: "0.3rem 0.5rem",
+                        border: "none",
+                        background: pill.value === opt.value ? "var(--color-surface-hover)" : "none",
+                        borderRadius: 4,
+                        cursor: "pointer",
+                        fontSize: "var(--font-size-sm)",
+                        fontWeight: pill.value === opt.value ? 700 : 400,
+                      }}
+                    >
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/client/src/components/shared/YearFilter.js
+++ b/client/src/components/shared/YearFilter.js
@@ -5,11 +5,11 @@ import React from "react";
  * pages (Timeline, My Memories, Shared, Recommendations). Reuses the
  * `.status-toggle` pill styling so it matches the Attended/Wishlist row.
  *
- * Renders nothing unless there are at least two years to choose between — a
- * single-year list gains nothing from a year filter.
+ * Renders nothing only when there are no dated items at all; a single year still
+ * shows (All + that year) so the control is present wherever any data exists.
  */
 function YearFilter({ years, value, onChange }) {
-  if (!years || years.length < 2) return null;
+  if (!years || years.length < 1) return null;
 
   return (
     <div className="status-toggle mb-2" role="group" aria-label="Year filter">

--- a/client/src/features/cars/components/CarList.js
+++ b/client/src/features/cars/components/CarList.js
@@ -18,6 +18,10 @@ import {
   getStatusLabel,
 } from "../../../helpers/filterUtils";
 
+// Cars often lack a purchase date; fall back to the model year so the Year
+// filter still groups them. Module-level for a stable dateField identity.
+const CAR_DATE = (c) => c.startDate || (c.year ? `${c.year}-01-01` : c.createdAt);
+
 function CarList() {
   const [carFilter, setCarFilter] = React.useState("all");
   const { profile } = useAppData();
@@ -35,7 +39,7 @@ function CarList() {
 
   const carStatuses = getStatusFilterOptions("cars");
   const statusFiltered = filterByStatus(cars, filterStatus);
-  const lf = useListFilters(cars, { dateField: "startDate" });
+  const lf = useListFilters(cars, { dateField: CAR_DATE });
   const commonFiltered = lf.applyCommonFilters(statusFiltered);
 
   const filteredCars = React.useMemo(() => {

--- a/client/src/features/cellar/components/CellarList.js
+++ b/client/src/features/cellar/components/CellarList.js
@@ -7,7 +7,8 @@ import SaveToast from "../../../components/shared/SaveToast";
 import SnapCaptureModal from "../../../components/shared/SnapCaptureModal";
 import EntryDetailPanel from "../../../components/shared/EntryDetailPanel";
 import CategoryListHeader from "../../../components/shared/CategoryListHeader";
-import { RATING_GROUP } from "../../../components/shared/GroupedDropdownFilter";
+import MultiPillFilter from "../../../components/shared/MultiPillFilter";
+import { RATING_PILL_OPTIONS, matchesRatingValue } from "../../../components/shared/GroupedDropdownFilter";
 import cellarSchema, { WINE_TYPES, WHISKEY_TYPES } from "../cellarSchema";
 import useCategory from "../../../hooks/useCategory";
 import useListFilters from "../../../hooks/useListFilters";
@@ -28,7 +29,11 @@ const WHISKEY_TYPE_EMOJIS = {
 };
 
 function CellarList() {
-  const [subFilter, setSubFilter] = useState("all");
+  const [subTypeFilter, setSubTypeFilter] = useState("all");
+  const [wineTypeFilter, setWineTypeFilter] = useState("all");
+  const [varietalFilter, setVarietalFilter] = useState("all");
+  const [whiskeyTypeFilter, setWhiskeyTypeFilter] = useState("all");
+  const [ratingFilter, setRatingFilter] = useState("all");
   const { profile } = useAppData();
 
   const {
@@ -67,65 +72,70 @@ function CellarList() {
     return [...varietalSet].sort();
   }, [cellarItems]);
 
-  // Single-select pill model (Movie-style): one "Type" pill for Wine/Whiskey,
-  // plus dependent sub-type / varietal / rating pills, all sharing one value.
-  const cellarFilterGroups = useMemo(() => {
-    const groups = [
+  // Contextual multi-pill model: a persistent Type pill (Wine/Whiskey) drives
+  // which sub-pills show; with no Type chosen, both sets are available. Each pill
+  // holds its own value so selections combine (e.g. Wine + Red + 4★).
+  const isWineCtx = (v) => v.subtype === "all" || v.subtype === "wine";
+  const isWhiskeyCtx = (v) => v.subtype === "all" || v.subtype === "whiskey";
+  const cellarPills = useMemo(() => {
+    const pills = [
       {
         key: "subtype",
         label: "\u{1F37E} Type",
+        allLabel: "All Types",
+        value: subTypeFilter,
+        onChange: setSubTypeFilter,
         options: [
-          { value: "subtype:wine", label: "\u{1F377} Wine" },
-          { value: "subtype:whiskey", label: "\u{1F943} Whiskey" },
+          { value: "wine", label: "\u{1F377} Wine" },
+          { value: "whiskey", label: "\u{1F943} Whiskey" },
         ],
       },
       {
         key: "wineType",
         label: "\u{1F347} Wine Type",
-        options: WINE_TYPES.map((t) => ({
-          value: `wine:${t}`,
-          label: `${WINE_TYPE_EMOJIS[t] || "\u{1F377}"} ${t}`,
-        })),
+        value: wineTypeFilter,
+        onChange: setWineTypeFilter,
+        options: WINE_TYPES.map((t) => ({ value: t, label: `${WINE_TYPE_EMOJIS[t] || "\u{1F377}"} ${t}` })),
+        visibleWhen: isWineCtx,
       },
     ];
     if (availableVarietals.length > 0) {
-      groups.push({
+      pills.push({
         key: "varietal",
         label: "\u{1F377} Varietal",
-        options: availableVarietals.map((v) => ({ value: `varietal:${v}`, label: v })),
+        value: varietalFilter,
+        onChange: setVarietalFilter,
+        options: availableVarietals.map((v) => ({ value: v, label: v })),
+        visibleWhen: isWineCtx,
       });
     }
-    groups.push({
+    pills.push({
       key: "whiskeyType",
       label: "\u{1F943} Whiskey Type",
-      options: WHISKEY_TYPES.map((t) => ({
-        value: `whiskey:${t}`,
-        label: `${WHISKEY_TYPE_EMOJIS[t] || "\u{1F943}"} ${t}`,
-      })),
+      value: whiskeyTypeFilter,
+      onChange: setWhiskeyTypeFilter,
+      options: WHISKEY_TYPES.map((t) => ({ value: t, label: `${WHISKEY_TYPE_EMOJIS[t] || "\u{1F943}"} ${t}` })),
+      visibleWhen: isWhiskeyCtx,
     });
-    groups.push(RATING_GROUP);
-    return groups;
-  }, [availableVarietals]);
+    pills.push({
+      key: "rating",
+      label: "★ Rating",
+      value: ratingFilter,
+      onChange: setRatingFilter,
+      options: RATING_PILL_OPTIONS,
+    });
+    return pills;
+  }, [availableVarietals, subTypeFilter, wineTypeFilter, varietalFilter, whiskeyTypeFilter, ratingFilter]);
 
   const filteredItems = useMemo(() => {
-    if (subFilter === "all") return commonFiltered;
-    const [type, val] = subFilter.split(":");
-    if (type === "subtype") return commonFiltered.filter((i) => (i.subType || "wine") === val);
-    if (type === "wine") return commonFiltered.filter((i) => i.wineType === val);
-    if (type === "whiskey") return commonFiltered.filter((i) => i.whiskyType === val);
-    if (type === "varietal") return commonFiltered.filter((i) => i.varietal === val);
-    if (type === "rating") {
-      return commonFiltered.filter((i) => {
-        const r = parseInt(i.rating, 10);
-        if (val === "unrated") return !r;
-        if (val === "5") return r === 5;
-        if (val === "4+") return r >= 4;
-        if (val === "3+") return r >= 3;
-        return true;
-      });
-    }
-    return commonFiltered;
-  }, [commonFiltered, subFilter]);
+    let items = commonFiltered;
+    if (subTypeFilter !== "all") items = items.filter((i) => (i.subType || "wine") === subTypeFilter);
+    if (wineTypeFilter !== "all") items = items.filter((i) => i.wineType === wineTypeFilter);
+    if (varietalFilter !== "all") items = items.filter((i) => i.varietal === varietalFilter);
+    if (whiskeyTypeFilter !== "all") items = items.filter((i) => i.whiskyType === whiskeyTypeFilter);
+    if (ratingFilter !== "all") items = items.filter((i) => matchesRatingValue(i.rating, ratingFilter));
+    return items;
+  }, [commonFiltered, subTypeFilter, wineTypeFilter, varietalFilter, whiskeyTypeFilter, ratingFilter]);
 
   const getItemIcon = (item) => {
     return (item.subType || "wine") === "whiskey" ? "\u{1F943}" : "\u{1F377}";
@@ -156,10 +166,9 @@ function CellarList() {
         yearOptions={lf.yearOptions}
         activeYear={lf.activeYear}
         onYearChange={lf.setActiveYear}
-        filterGroups={cellarFilterGroups}
-        filterValue={subFilter}
-        onFilterChange={setSubFilter}
-        filterColor="var(--color-cellar, #8B3A8F)"
+        renderExtraFilters={() => (
+          <MultiPillFilter pills={cellarPills} color="var(--color-cellar, #8B3A8F)" />
+        )}
         sourceFilter={lf.sourceFilter}
         onSourceChange={lf.setSourceFilter}
         avatarUrl={profile?.avatar_url}

--- a/client/src/features/homes/components/HomeList.js
+++ b/client/src/features/homes/components/HomeList.js
@@ -18,6 +18,10 @@ import {
   getStatusLabel,
 } from "../../../helpers/filterUtils";
 
+// Homes have no startDate — they record purchase/sold dates. Module-level for a
+// stable dateField identity across renders.
+const HOME_DATE_FIELDS = ["purchaseDate", "soldDate", "createdAt"];
+
 function HomeList() {
   const [homeFilter, setHomeFilter] = React.useState("all");
   const { profile } = useAppData();
@@ -35,7 +39,7 @@ function HomeList() {
 
   const homeStatuses = getStatusFilterOptions("homes");
   const statusFiltered = filterByStatus(homes, filterStatus);
-  const lf = useListFilters(homes, { dateField: "startDate" });
+  const lf = useListFilters(homes, { dateField: HOME_DATE_FIELDS });
   const commonFiltered = lf.applyCommonFilters(statusFiltered);
 
   const filteredHomes = React.useMemo(() => {

--- a/client/src/features/kids/components/KidsList.js
+++ b/client/src/features/kids/components/KidsList.js
@@ -7,7 +7,8 @@ import SaveToast from "../../../components/shared/SaveToast";
 import SnapCaptureModal from "../../../components/shared/SnapCaptureModal";
 import EntryDetailPanel from "../../../components/shared/EntryDetailPanel";
 import CategoryListHeader from "../../../components/shared/CategoryListHeader";
-import { RATING_GROUP } from "../../../components/shared/GroupedDropdownFilter";
+import MultiPillFilter from "../../../components/shared/MultiPillFilter";
+import { RATING_PILL_OPTIONS, matchesRatingValue } from "../../../components/shared/GroupedDropdownFilter";
 import kidsSchema, { KIDS_EVENT_TYPES } from "../kidsSchema";
 import useCategory from "../../../hooks/useCategory";
 import useListFilters from "../../../hooks/useListFilters";
@@ -28,93 +29,6 @@ function getAgeAtDate(birthday, eventDate) {
     age--;
   }
   return age >= 0 ? age : null;
-}
-
-function MilestoneTypeFilter({ value, onChange }) {
-  return (
-    <div className="d-flex gap-2 flex-wrap mb-3">
-      <button
-        type="button"
-        onClick={() => onChange("all")}
-        style={{
-          padding: "0.3rem 0.75rem",
-          borderRadius: "20px",
-          border: "2px solid var(--color-kids, #FF6B35)",
-          background: value === "all" ? "var(--color-kids, #FF6B35)" : "transparent",
-          color: value === "all" ? "#fff" : "var(--color-kids, #FF6B35)",
-          fontWeight: 600,
-          fontSize: "var(--font-size-sm)",
-          cursor: "pointer",
-        }}
-      >
-        All
-      </button>
-      {KIDS_EVENT_TYPES.map((t) => (
-        <button
-          key={t.value}
-          type="button"
-          onClick={() => onChange(t.value)}
-          style={{
-            padding: "0.3rem 0.75rem",
-            borderRadius: "20px",
-            border: "2px solid var(--color-kids, #FF6B35)",
-            background: value === t.value ? "var(--color-kids, #FF6B35)" : "transparent",
-            color: value === t.value ? "#fff" : "var(--color-kids, #FF6B35)",
-            fontWeight: 600,
-            fontSize: "var(--font-size-sm)",
-            cursor: "pointer",
-          }}
-        >
-          {t.label}
-        </button>
-      ))}
-    </div>
-  );
-}
-
-function ChildFilter({ contacts, value, onChange }) {
-  const children = contacts.filter((c) => c.isChild);
-  if (children.length <= 1) return null;
-
-  return (
-    <div className="d-flex gap-2 flex-wrap mb-3">
-      <button
-        type="button"
-        onClick={() => onChange("all")}
-        style={{
-          padding: "0.3rem 0.75rem",
-          borderRadius: "20px",
-          border: "2px solid var(--color-text-tertiary)",
-          background: value === "all" ? "var(--color-text-secondary)" : "transparent",
-          color: value === "all" ? "#fff" : "var(--color-text-secondary)",
-          fontWeight: 600,
-          fontSize: "var(--font-size-sm)",
-          cursor: "pointer",
-        }}
-      >
-        All Kids
-      </button>
-      {children.map((child) => (
-        <button
-          key={child.id}
-          type="button"
-          onClick={() => onChange(child.id)}
-          style={{
-            padding: "0.3rem 0.75rem",
-            borderRadius: "20px",
-            border: "2px solid var(--color-kids, #FF6B35)",
-            background: value === child.id ? "var(--color-kids, #FF6B35)" : "transparent",
-            color: value === child.id ? "#fff" : "var(--color-kids, #FF6B35)",
-            fontWeight: 600,
-            fontSize: "var(--font-size-sm)",
-            cursor: "pointer",
-          }}
-        >
-          {child.displayName}
-        </button>
-      ))}
-    </div>
-  );
 }
 
 function KidsStats({ items, contacts }) {
@@ -192,19 +106,43 @@ function KidsList() {
     let items = commonFiltered
       .filter((i) => milestoneTypeFilter === "all" || i.milestoneType === milestoneTypeFilter)
       .filter((i) => childFilter === "all" || i.childContactId === childFilter);
-    if (ratingFilter !== "all" && ratingFilter.startsWith("rating:")) {
-      const rVal = ratingFilter.split(":")[1];
-      items = items.filter((i) => {
-        const r = parseInt(i.rating, 10);
-        if (rVal === "unrated") return !r;
-        if (rVal === "5") return r === 5;
-        if (rVal === "4+") return r >= 4;
-        if (rVal === "3+") return r >= 3;
-        return true;
-      });
+    if (ratingFilter !== "all") {
+      items = items.filter((i) => matchesRatingValue(i.rating, ratingFilter));
     }
     return items;
   }, [commonFiltered, milestoneTypeFilter, childFilter, ratingFilter]);
+
+  // One combinable pill row: Child (when 2+ kids) + Milestone Type + Rating.
+  const kidsPills = useMemo(() => {
+    const children = contacts.filter((c) => c.isChild);
+    const pills = [];
+    if (children.length > 1) {
+      pills.push({
+        key: "child",
+        label: "\u{1F9D2} Child",
+        allLabel: "All Kids",
+        value: childFilter,
+        onChange: setChildFilter,
+        color: "var(--color-text-secondary)",
+        options: children.map((c) => ({ value: c.id, label: c.displayName })),
+      });
+    }
+    pills.push({
+      key: "milestoneType",
+      label: "\u{1F31F} Type",
+      value: milestoneTypeFilter,
+      onChange: setMilestoneTypeFilter,
+      options: KIDS_EVENT_TYPES.map((t) => ({ value: t.value, label: t.label })),
+    });
+    pills.push({
+      key: "rating",
+      label: "★ Rating",
+      value: ratingFilter,
+      onChange: setRatingFilter,
+      options: RATING_PILL_OPTIONS,
+    });
+    return pills;
+  }, [contacts, childFilter, milestoneTypeFilter, ratingFilter]);
 
   const groupedByYear = useMemo(() => {
     const groups = {};
@@ -245,9 +183,6 @@ function KidsList() {
         title={"\u{1F31F} Kids"}
         addLabel="+ Log Milestone"
         onAdd={openForm}
-        stats={milestones.length > 0 ? [
-          { value: milestones.length, label: "milestones", color: "var(--color-kids, #E91E63)" },
-        ] : null}
         category="kids"
         statusOptions={kidsStatuses}
         filterStatus={filterStatus}
@@ -258,14 +193,9 @@ function KidsList() {
         renderExtraFilters={() => (
           <>
             <KidsStats items={milestones} contacts={contacts} />
-            <ChildFilter contacts={contacts} value={childFilter} onChange={setChildFilter} />
-            <MilestoneTypeFilter value={milestoneTypeFilter} onChange={setMilestoneTypeFilter} />
+            <MultiPillFilter pills={kidsPills} color="var(--color-kids, #FF6B35)" />
           </>
         )}
-        filterGroups={[RATING_GROUP]}
-        filterValue={ratingFilter}
-        onFilterChange={setRatingFilter}
-        filterColor="var(--color-kids, #FF6B35)"
         sourceFilter={lf.sourceFilter}
         onSourceChange={lf.setSourceFilter}
         avatarUrl={profile?.avatar_url}

--- a/client/src/helpers/filterUtils.js
+++ b/client/src/helpers/filterUtils.js
@@ -48,11 +48,15 @@ function getItemDateValue(item, dateField = DEFAULT_DATE_FIELDS) {
   return "";
 }
 
-/** Extracts a 4-digit year from a date string (date-only or full ISO timestamp). */
+/**
+ * Extracts a 4-digit year from a date string (date-only or full ISO timestamp).
+ * Uses the calendar-date portion (YYYY-MM-DD) parsed as local midnight so a
+ * UTC-midnight timestamp doesn't roll back into the previous year in
+ * negative-offset timezones.
+ */
 function yearOf(value) {
   if (!value) return NaN;
-  const s = String(value);
-  const dt = s.length <= 10 ? new Date(s + "T00:00:00") : new Date(s);
+  const dt = new Date(String(value).slice(0, 10) + "T00:00:00");
   return dt.getFullYear();
 }
 

--- a/client/src/pages/Recommendations.js
+++ b/client/src/pages/Recommendations.js
@@ -219,7 +219,7 @@ function Recommendations() {
       <YearFilter years={yearOptions} value={activeYear} onChange={setActiveYear} />
 
       {/* Category filter — single pill, matching the category pages */}
-      {categories.length > 1 && (
+      {categories.length >= 1 && (
         <GroupedDropdownFilter
           groups={categoryFilterGroups}
           value={categoryFilter}

--- a/client/src/pages/SharedFeed.js
+++ b/client/src/pages/SharedFeed.js
@@ -499,7 +499,7 @@ function SharedFeed() {
       <YearFilter years={yearOptions} value={activeYear} onChange={setActiveYear} />
 
       {/* Category filter — single pill, matching the category pages */}
-      {categories.length > 1 && (
+      {categories.length >= 1 && (
         <GroupedDropdownFilter
           groups={categoryFilterGroups}
           value={categoryFilter}

--- a/client/src/pages/Snaps.js
+++ b/client/src/pages/Snaps.js
@@ -158,6 +158,7 @@ function Snaps() {
   const filterBySource = (items) => {
     if (sourceFilter === "mine") return items.filter((i) => !i.isShared);
     if (sourceFilter === "shared") return items.filter((i) => i.isShared);
+    if (sourceFilter === "recommended") return items.filter((i) => i.rawItem?._isRecommended);
     return items;
   };
 
@@ -260,6 +261,7 @@ function Snaps() {
         onChange={setSourceFilter}
         avatarUrl={profile?.avatar_url}
         sharedCount={[...allSnaps, ...allPhotos].filter((i) => i.isShared).length}
+        recommendedCount={[...allSnaps, ...allPhotos].filter((i) => i.rawItem?._isRecommended).length}
       />
 
       {isEmpty ? (

--- a/client/src/pages/Snaps.js
+++ b/client/src/pages/Snaps.js
@@ -12,6 +12,7 @@ import dataService from "../services/dataService";
 import SourceFilterPills from "../components/shared/SourceFilterPills";
 import StatsStrip from "../components/shared/StatsStrip";
 import YearFilter from "../components/shared/YearFilter";
+import DoneWishlistFilter, { matchesDoneWishlist } from "../components/shared/DoneWishlistFilter";
 import { getYearOptions, filterByYear } from "../helpers/filterUtils";
 import EntryDetailPanel from "../components/shared/EntryDetailPanel";
 import { useAppData } from "../contexts/AppDataContext";
@@ -32,6 +33,7 @@ function Snaps() {
   const [activeView, setActiveView] = useState("all");
   const [activeCategory, setActiveCategory] = useState("all");
   const [activeYear, setActiveYear] = useState("all");
+  const [activeStatus, setActiveStatus] = useState("all");
   const [sourceFilter, setSourceFilter] = useState("all");
   const [allSnaps, setAllSnaps] = useState([]);
   const [allPhotos, setAllPhotos] = useState([]);
@@ -164,11 +166,14 @@ function Snaps() {
 
   const filterByYearLocal = (items) => filterByYear(items, activeYear, "date");
 
+  const filterByStatusLocal = (items) =>
+    items.filter((i) => matchesDoneWishlist(i.rawItem?.status, activeStatus));
+
   const sortByDate = (items) =>
     [...items].sort((a, b) => b.date.localeCompare(a.date));
 
   const applyFilters = (items) =>
-    sortByDate(filterBySource(filterByYearLocal(filterByCategory(items))));
+    sortByDate(filterBySource(filterByYearLocal(filterByStatusLocal(filterByCategory(items)))));
 
   const yearOptions = getYearOptions([...allSnaps, ...allPhotos], "date");
   const filteredSnaps = applyFilters(allSnaps);
@@ -205,7 +210,10 @@ function Snaps() {
         ]} />
       )}
 
-      {/* Year filter (renders only when 2+ years exist) */}
+      {/* Done / Wishlist status */}
+      <DoneWishlistFilter value={activeStatus} onChange={setActiveStatus} />
+
+      {/* Year filter (renders whenever any dated items exist) */}
       <YearFilter years={yearOptions} value={activeYear} onChange={setActiveYear} />
 
       {/* Category filter pills */}

--- a/client/src/pages/Timeline.js
+++ b/client/src/pages/Timeline.js
@@ -114,11 +114,13 @@ function Timeline() {
     });
   }
 
-  // Apply source filter (All / Mine / Shared)
+  // Apply source filter (All / Mine / Shared / Recommended)
   if (sourceFilter === "mine") {
     filteredEntries = filteredEntries.filter((e) => !e.isShared);
   } else if (sourceFilter === "shared") {
     filteredEntries = filteredEntries.filter((e) => e.isShared);
+  } else if (sourceFilter === "recommended") {
+    filteredEntries = filteredEntries.filter((e) => e.rawItem?._isRecommended);
   }
 
   // Get months that have entries for the selected year (for month pills)
@@ -195,12 +197,13 @@ function Timeline() {
         </div>
       )}
 
-      {/* Source filter (All / Mine / Shared) */}
+      {/* Source filter (All / Mine / Shared / Recommended) */}
       <SourceFilterPills
         value={sourceFilter}
         onChange={setSourceFilter}
         avatarUrl={profile?.avatar_url}
         sharedCount={allEntries.filter((e) => e.isShared).length}
+        recommendedCount={allEntries.filter((e) => e.rawItem?._isRecommended).length}
       />
 
       {groupedMonths.length === 0 ? (

--- a/client/src/pages/Timeline.js
+++ b/client/src/pages/Timeline.js
@@ -10,6 +10,7 @@ import SourceFilterPills from "../components/shared/SourceFilterPills";
 import EntryDetailPanel from "../components/shared/EntryDetailPanel";
 import StatsStrip from "../components/shared/StatsStrip";
 import YearFilter from "../components/shared/YearFilter";
+import DoneWishlistFilter, { matchesDoneWishlist } from "../components/shared/DoneWishlistFilter";
 import { useAppData } from "../contexts/AppDataContext";
 import { SCHEMA_MAP, CATEGORY_KEYS } from "../helpers/schemaRegistry";
 import { enrichItemsWithSocialContent, getSocialPreview } from "../helpers/socialContent";
@@ -27,6 +28,8 @@ const MONTH_NAMES = [
 function Timeline() {
   const [activeYear, setActiveYear] = useState("all");
   const [activeMonth, setActiveMonth] = useState("all");
+  const [activeStatus, setActiveStatus] = useState("all");
+  const [activeCategory, setActiveCategory] = useState("all");
   const [sourceFilter, setSourceFilter] = useState("all");
   const [allEntries, setAllEntries] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -99,6 +102,8 @@ function Timeline() {
     ),
   ].sort((a, b) => b - a);
 
+  const timelineCategories = [...new Set(allEntries.map((e) => e.category).filter(Boolean))];
+
   // Apply year filter
   let filteredEntries = activeYear === "all"
     ? allEntries
@@ -112,6 +117,16 @@ function Timeline() {
       const d = new Date(e.date + "T00:00:00");
       return d.getMonth() === parseInt(activeMonth);
     });
+  }
+
+  // Apply Done/Wishlist status filter
+  if (activeStatus !== "all") {
+    filteredEntries = filteredEntries.filter((e) => matchesDoneWishlist(e.status, activeStatus));
+  }
+
+  // Apply category filter
+  if (activeCategory !== "all") {
+    filteredEntries = filteredEntries.filter((e) => e.category === activeCategory);
   }
 
   // Apply source filter (All / Mine / Shared / Recommended)
@@ -169,7 +184,10 @@ function Timeline() {
         return <StatsStrip stats={stats} />;
       })()}
 
-      {/* Year filter (shared component; renders only when 2+ years exist) */}
+      {/* Done / Wishlist status */}
+      <DoneWishlistFilter value={activeStatus} onChange={setActiveStatus} />
+
+      {/* Year filter (shared component; renders whenever any dated items exist) */}
       <YearFilter
         years={years}
         value={activeYear}
@@ -194,6 +212,30 @@ function Timeline() {
               {MONTH_NAMES[m]}
             </button>
           ))}
+        </div>
+      )}
+
+      {/* Category filter */}
+      {timelineCategories.length > 1 && (
+        <div className="status-toggle mb-2">
+          <button
+            className={`btn ${activeCategory === "all" ? "active" : ""}`}
+            onClick={() => setActiveCategory("all")}
+          >
+            All
+          </button>
+          {timelineCategories.map((cat) => {
+            const meta = categoryMeta[cat] || {};
+            return (
+              <button
+                key={cat}
+                className={`btn ${activeCategory === cat ? "active" : ""}`}
+                onClick={() => setActiveCategory(cat)}
+              >
+                {meta.icon} {cat.charAt(0).toUpperCase() + cat.slice(1)}
+              </button>
+            );
+          })}
         </div>
       )}
 


### PR DESCRIPTION
Addresses the filter requirements that the prior normalization PR missed, plus two real bugs surfaced while diagnosing them.

## Bugs fixed
- **Recommended showed everything** on Timeline & My Memories — those pages never had a `recommended` branch in their source filter, and `SourceFilterPills` only disables the pill when `recommendedCount === 0` is passed (they passed nothing). Added the branch + the count.
- **Homes Year filter never populated** — `useListFilters` was reading `startDate`, but homes have no such field (they use `purchaseDate`/`soldDate`). Fixed the date field.
- **Year rolled back across year boundary** — `yearOf` parsed UTC-midnight timestamps in local time; now uses the calendar-date portion.

## Missed requirements
| Item | Fix |
|---|---|
| Year hidden on sparse pages | `YearFilter` renders at 1+ year (was 2+) |
| Cars year | Falls back to model year when no purchase date |
| Timeline/Memories status | New shared **Done / Wishlist** filter (collapses visited/attended/watched/owned/tried) |
| Timeline category filter | Added category pill |
| Shared/Recs year+category | Render with 1+ (pairs with the 1+ year change) |
| Kids double stats | Dropped the duplicate `stats` prop; keep `KidsStats` |
| Kids filter row | Child + Type + Rating in one combinable row |
| Cellar UX | Persistent Type pill drives contextual sub-pills; selections combine |

## New shared component
`MultiPillFilter` — each pill owns its value (selections stack) with optional `visibleWhen` for contextual show/hide. Powers Cellar (Type→sub) and Kids (Child+Type+Rating). Complements the single-select `GroupedDropdownFilter`.

## Process fix
Worked from a per-page requirement matrix this time; verified each change's logic with `node` checks (recommended branch, Done/Wishlist collapse, TZ-safe year, Cars/Homes date resolution, combinable + contextual pills).

## Verification
- ✅ `npx react-scripts build` clean
- ✅ 130/130 tests pass
- ⚠️ Authenticated UI spot-check still yours to do (app is login-gated): confirm Recommended now filters, Done/Wishlist works on Timeline/Memories, and the Cellar Type→sub contextual pills behave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)