### PR TITLE
feat(movies): stats scope toggle + agreements/disagreements

### DIFF
--- a/client/src/features/movies/components/MovieStatsPage.js
+++ b/client/src/features/movies/components/MovieStatsPage.js
@@ -30,6 +30,45 @@ function AlignmentBar({ score, color }) {
 export default function MovieStatsPage() {
   const { items: movies, contacts, loading, periodFilter, setPeriodFilter, stats, socialStats, socialLoading, hasLinkedContacts } = useStatsPage("movies", computeMovieStats, computeSocialMovieStats);
 
+  // Scope toggle: recompute the personal panels for Mine / My Circle / one person.
+  const [scope, setScope] = React.useState("mine");
+
+  const scopeContacts = React.useMemo(() => {
+    const sm = socialStats?.socialMovies;
+    if (!sm) return [];
+    const counts = {};
+    sm.forEach((m) => { if (m._sharedByUserId) counts[m._sharedByUserId] = (counts[m._sharedByUserId] || 0) + 1; });
+    return contacts
+      .map((c) => ({ uid: c.linkedUserId || c.linked_user_id, name: c.display_name || c.displayName, ring: c.ring_level || c.ringLevel }))
+      .filter((c) => c.uid && counts[c.uid])
+      .map((c) => ({ ...c, count: counts[c.uid] }))
+      .sort((a, b) => b.count - a.count);
+  }, [socialStats, contacts]);
+
+  // Reset to Mine if the selected person is no longer present.
+  const scopeValid = scope === "mine" || scope === "circle" || scopeContacts.some((c) => c.uid === scope);
+  const activeScope = scopeValid ? scope : "mine";
+
+  const scopedStats = React.useMemo(() => {
+    if (activeScope === "mine") return stats;
+    const sm = socialStats?.socialMovies || [];
+    const src = activeScope === "circle" ? sm : sm.filter((m) => m._sharedByUserId === activeScope);
+    const normalized = src.map((m) => ({
+      ...m,
+      status: "watched",
+      rating: m._socialRating != null ? String(m._socialRating) : (m.rating || ""),
+    }));
+    // Circle/individual movies rarely carry a watch-date, so compute all-time
+    // rather than letting the (Mine-oriented) period filter zero them out.
+    return computeMovieStats(normalized, "all");
+  }, [activeScope, stats, socialStats]);
+
+  const scopeLabel = activeScope === "mine"
+    ? "you"
+    : activeScope === "circle"
+      ? "your circle"
+      : (scopeContacts.find((c) => c.uid === activeScope)?.name || "this person");
+
   if (loading) {
     return <div style={{ padding: "2rem", textAlign: "center", color: "var(--color-text-tertiary)" }}>Loading stats...</div>;
   }
@@ -47,10 +86,10 @@ export default function MovieStatsPage() {
       periodFilter={periodFilter}
       onPeriodChange={setPeriodFilter}
       heroStats={hasData ? [
-        { label: "Watched", value: stats.totalWatched, color: "var(--color-movies, #E91E63)" },
-        { label: "Watchlist", value: stats.totalWatchlist, color: "var(--color-text-secondary)" },
-        { label: "Avg Rating", value: stats.avgRating.toFixed(1), sub: `of ${stats.totalWatched} rated`, color: "var(--color-movies, #E91E63)" },
-        { label: "Genres", value: stats.genresExplored, sub: "explored", color: "var(--color-primary)" },
+        { label: "Watched", value: scopedStats.totalWatched, color: "var(--color-movies, #E91E63)" },
+        { label: "Watchlist", value: scopedStats.totalWatchlist, color: "var(--color-text-secondary)" },
+        { label: "Avg Rating", value: scopedStats.avgRating.toFixed(1), sub: `of ${scopedStats.totalWatched} rated`, color: "var(--color-movies, #E91E63)" },
+        { label: "Genres", value: scopedStats.genresExplored, sub: "explored", color: "var(--color-primary)" },
       ] : null}
     >
       {!hasData ? (
@@ -63,18 +102,37 @@ export default function MovieStatsPage() {
         </div>
       ) : (
         <>
+          {/* Scope toggle — recomputes the breakdown panels below for the chosen lens */}
+          {scopeContacts.length > 0 && (
+            <div style={{ display: "flex", alignItems: "center", gap: "0.4rem", flexWrap: "wrap", marginBottom: "1rem" }}>
+              <span style={{ fontSize: "var(--font-size-xs)", fontWeight: 700, color: "var(--color-text-tertiary)", textTransform: "uppercase", letterSpacing: "0.05em", marginRight: "0.25rem" }}>
+                Whose stats
+              </span>
+              <ScopePill active={activeScope === "mine"} onClick={() => setScope("mine")} label={"\u{1F9D1} Mine"} />
+              <ScopePill active={activeScope === "circle"} onClick={() => setScope("circle")} label={"\u{1F465} My Circle"} />
+              {scopeContacts.map((c) => (
+                <ScopePill key={c.uid} active={activeScope === c.uid} onClick={() => setScope(c.uid)} label={c.name} ring={c.ring} />
+              ))}
+            </div>
+          )}
+          {activeScope !== "mine" && (
+            <div style={{ fontSize: "var(--font-size-sm)", color: "var(--color-text-secondary)", marginBottom: "1rem" }}>
+              Showing the all-time breakdown for <strong>{scopeLabel}</strong> — the social panels below always compare across your circle.
+            </div>
+          )}
+
           {/* Personal Stats */}
           <Row className="g-4 mb-4">
             <Col md={6}>
               <div style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "var(--card-radius)", padding: "1.25rem" }}>
                 <SectionHeader emoji={"\u{1F3AD}"}>Genre Breakdown</SectionHeader>
-                <HorizontalBar items={stats.genreBreakdown.slice(0, 8)} color="var(--color-movies, #E91E63)" />
+                <HorizontalBar items={scopedStats.genreBreakdown.slice(0, 8)} color="var(--color-movies, #E91E63)" />
               </div>
             </Col>
             <Col md={6}>
               <div style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "var(--card-radius)", padding: "1.25rem" }}>
                 <SectionHeader emoji={"⭐"}>Rating Distribution</SectionHeader>
-                <BarChart data={stats.ratingDistribution} color="var(--color-movies, #E91E63)" />
+                <BarChart data={scopedStats.ratingDistribution} color="var(--color-movies, #E91E63)" />
               </div>
             </Col>
           </Row>
@@ -83,14 +141,14 @@ export default function MovieStatsPage() {
             <Col md={6}>
               <div style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "var(--card-radius)", padding: "1.25rem" }}>
                 <SectionHeader emoji={"\u{1F4C5}"}>Movies by Year Watched</SectionHeader>
-                <BarChart data={stats.watchedByYear} color="var(--color-movies, #E91E63)" />
+                <BarChart data={scopedStats.watchedByYear} color="var(--color-movies, #E91E63)" />
               </div>
             </Col>
             <Col md={6}>
               <div style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "var(--card-radius)", padding: "1.25rem" }}>
                 <SectionHeader emoji={"\u{1F4C0}"}>Decade Distribution</SectionHeader>
                 <HorizontalBar
-                  items={Object.entries(stats.decadeFreq).map(([name, count]) => ({ name, count })).sort((a, b) => b.count - a.count)}
+                  items={Object.entries(scopedStats.decadeFreq).map(([name, count]) => ({ name, count })).sort((a, b) => b.count - a.count)}
                   color="#9C27B0"
                 />
               </div>
@@ -101,8 +159,8 @@ export default function MovieStatsPage() {
             <Col md={6}>
               <div style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "var(--card-radius)", padding: "1.25rem" }}>
                 <SectionHeader emoji={"\u{1F3AC}"}>Top Directors</SectionHeader>
-                {stats.topDirectors.length > 0 ? (
-                  <HorizontalBar items={stats.topDirectors.slice(0, 6)} color="#FF5722" />
+                {scopedStats.topDirectors.length > 0 ? (
+                  <HorizontalBar items={scopedStats.topDirectors.slice(0, 6)} color="#FF5722" />
                 ) : (
                   <div style={{ color: "var(--color-text-tertiary)", fontSize: "var(--font-size-sm)" }}>Add directors to your movies to see this.</div>
                 )}
@@ -111,9 +169,9 @@ export default function MovieStatsPage() {
             <Col md={6}>
               <div style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "var(--card-radius)", padding: "1.25rem" }}>
                 <SectionHeader emoji={"\u{1F465}"}>Movie Companions</SectionHeader>
-                {stats.topCompanions.length > 0 ? (
+                {scopedStats.topCompanions.length > 0 ? (
                   <div style={{ display: "flex", flexDirection: "column", gap: "0.4rem" }}>
-                    {stats.topCompanions.map((c) => (
+                    {scopedStats.topCompanions.map((c) => (
                       <div key={c.name} style={{ display: "flex", justifyContent: "space-between", fontSize: "var(--font-size-sm)" }}>
                         <span style={{ fontWeight: 600 }}>{c.name}</span>
                         <span style={{ color: "var(--color-text-secondary)" }}>{c.count} movies</span>
@@ -198,6 +256,35 @@ export default function MovieStatsPage() {
                       </div>
                     ))}
                   </div>
+                </div>
+              )}
+
+              {/* Agreements & Disagreements */}
+              {socialStats.agreements && (socialStats.agreements.agreed.length > 0 || socialStats.agreements.disagreed.length > 0) && (
+                <div style={{ background: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "var(--card-radius)", padding: "1.25rem", marginBottom: "1.5rem" }}>
+                  <SectionHeader emoji={"⚖️"}>Agreements &amp; Disagreements</SectionHeader>
+                  <Row className="g-4">
+                    <Col md={6}>
+                      <div style={{ fontWeight: 700, fontSize: "var(--font-size-sm)", marginBottom: "0.5rem", color: "var(--color-success)" }}>
+                        {"\u{1F91D}"} On the same page
+                      </div>
+                      {socialStats.agreements.agreed.length > 0 ? (
+                        socialStats.agreements.agreed.map((a, i) => <AgreementRow key={`ag-${a.tmdbId}-${i}`} entry={a} />)
+                      ) : (
+                        <div style={{ color: "var(--color-text-tertiary)", fontSize: "var(--font-size-sm)" }}>No close matches yet.</div>
+                      )}
+                    </Col>
+                    <Col md={6}>
+                      <div style={{ fontWeight: 700, fontSize: "var(--font-size-sm)", marginBottom: "0.5rem", color: "var(--color-danger, #E01E5A)" }}>
+                        {"\u{1F525}"} Hot takes — you clashed
+                      </div>
+                      {socialStats.agreements.disagreed.length > 0 ? (
+                        socialStats.agreements.disagreed.map((a, i) => <AgreementRow key={`dis-${a.tmdbId}-${i}`} entry={a} clash />)
+                      ) : (
+                        <div style={{ color: "var(--color-text-tertiary)", fontSize: "var(--font-size-sm)" }}>No big disagreements — you and your circle are aligned!</div>
+                      )}
+                    </Col>
+                  </Row>
                 </div>
               )}
 
@@ -305,6 +392,48 @@ export default function MovieStatsPage() {
         </>
       )}
     </StatsPageLayout>
+  );
+}
+
+function ScopePill({ active, onClick, label, ring }) {
+  const accent = ring ? RING_COLORS[ring] : "var(--color-movies, #E91E63)";
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        border: `1.5px solid ${active ? accent : "var(--color-border)"}`,
+        background: active ? accent : "var(--color-surface)",
+        color: active ? "#fff" : "var(--color-text-secondary)",
+        borderRadius: 16,
+        padding: "0.2rem 0.7rem",
+        fontSize: "var(--font-size-xs)",
+        fontWeight: 600,
+        cursor: "pointer",
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+function AgreementRow({ entry, clash }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: "0.6rem", padding: "0.35rem 0", borderBottom: "1px solid var(--color-border)" }}>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontWeight: 600, fontSize: "var(--font-size-sm)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+          {entry.title}
+        </div>
+        <div style={{ fontSize: "var(--font-size-xs)", color: "var(--color-text-tertiary)" }}>
+          You {entry.myRating}{"★"} · {entry.contactName} {entry.theirRating}{"★"}
+        </div>
+      </div>
+      {clash && (
+        <span style={{ fontSize: "var(--font-size-xs)", fontWeight: 700, color: "var(--color-danger, #E01E5A)", flexShrink: 0 }}>
+          {Math.abs(entry.myRating - entry.theirRating)}{"★"} apart
+        </span>
+      )}
+    </div>
   );
 }
 

--- a/client/src/services/socialMovieStats.js
+++ b/client/src/services/socialMovieStats.js
@@ -55,7 +55,59 @@ export async function computeSocialMovieStats(myMovies, contacts) {
     ? computeGenreOverlap(myMovies, moviesByContact[uid(alignments[0].contact)] || [])
     : [];
 
-  return { alignments, suggestions, influence, genreOverlap, socialMovies };
+  // Movies you and your circle agreed / disagreed on
+  const agreements = computeAgreements(myMovies, socialMovies, contacts);
+
+  return { alignments, suggestions, influence, genreOverlap, socialMovies, agreements };
+}
+
+/**
+ * Split movies that both the user and a circle member rated into those they
+ * agreed on (ratings within 1 star) and clashed on (3+ stars apart).
+ * One entry per (movie, friend) pair, so a movie several friends rated can
+ * appear multiple times with different counterparts.
+ */
+function computeAgreements(myMovies, socialMovies, contacts) {
+  const whoByUid = {};
+  contacts.forEach((c) => {
+    const u = uid(c);
+    if (u) whoByUid[u] = { name: c.display_name || c.displayName, ring: c.ring_level || c.ringLevel };
+  });
+
+  const myByTmdb = {};
+  myMovies.forEach((m) => {
+    if (m._isShared) return;
+    const r = parseInt(m.rating, 10);
+    if (m.tmdbId && m.status === "watched" && r > 0) {
+      myByTmdb[m.tmdbId] = { title: m.title, posterUrl: m.posterUrl, rating: r };
+    }
+  });
+
+  const agreed = [];
+  const disagreed = [];
+  socialMovies.forEach((m) => {
+    const mine = m.tmdbId && myByTmdb[m.tmdbId];
+    const theirRating = m._socialRating || parseInt(m.rating, 10) || 0;
+    if (!mine || !theirRating) return;
+    const who = whoByUid[m._sharedByUserId];
+    const entry = {
+      tmdbId: m.tmdbId,
+      title: mine.title,
+      posterUrl: mine.posterUrl,
+      myRating: mine.rating,
+      theirRating,
+      contactName: who?.name || "A friend",
+      contactRing: who?.ring,
+    };
+    const diff = Math.abs(mine.rating - theirRating);
+    if (diff <= 1) agreed.push(entry);
+    else if (diff >= 3) disagreed.push(entry);
+  });
+
+  agreed.sort((a, b) => (b.myRating + b.theirRating) - (a.myRating + a.theirRating));
+  disagreed.sort((a, b) => Math.abs(b.myRating - b.theirRating) - Math.abs(a.myRating - a.theirRating));
+
+  return { agreed: agreed.slice(0, 8), disagreed: disagreed.slice(0, 8) };
 }
 
 function findSharedLovedMovies(myMovies, theirMovies) {


### PR DESCRIPTION
## Summary

Fills the two remaining gaps from the movie-stats roadmap (most of it — circle compatibility, discover, influence, genre overlap — was already built).

### 1. "Whose stats" scope toggle
A pill row (**Mine / My Circle / each circle member**) above the breakdown panels. Selecting a scope recomputes the **hero numbers + genre breakdown, rating distribution, by-year, decades, top directors, and companions** for that lens via `computeMovieStats` over the scoped movie set:
- **Mine** — your own movies (respects the period filter).
- **My Circle** — all friends' shared movies aggregated.
- **A person** — just that contact's shared movies.

Circle/individual scopes compute **all-time** (friends' shared movies rarely carry a watch-date, so the Mine-oriented period filter would zero them out). The social comparison panels below are unchanged — they always span the whole circle.

### 2. Agreements & Disagreements
A two-column section over movies both you and a circle member rated:
- **On the same page** — ratings ≤1★ apart.
- **Hot takes — you clashed** — ratings ≥3★ apart, with an "N★ apart" badge.

Backed by a new `computeAgreements()` in `socialMovieStats.js` (one entry per movie/friend pair).

## Files
- `client/src/services/socialMovieStats.js` — `computeAgreements`, exposed as `agreements` on the social stats
- `client/src/features/movies/components/MovieStatsPage.js` — scope toggle, scoped recompute, agreements UI, `ScopePill` / `AgreementRow` helpers

## Notes
- Verified via clean `react-scripts build`; interactive verification needs auth + seeded multi-user social data, which isn't available in-session.
- Independent of #15 (movie detail/SERP/filters) — both branch off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)