### PR TITLE
chore: refresh movie docs + add computeAgreements test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ This project uses **React Bootstrap** (not Tailwind or shadcn). Follow the exist
 - **`hooks/useCategory.js`:** All CRUD, filtering, modals, and social sharing per category. Do not duplicate this logic in feature components.
 - **dataService.js:** All DB access goes through here. Never call Supabase directly from components.
 - **RLS handles authorization:** No app-level permission checks needed for data access.
-- **Photos:** Compress client-side → upload to Supabase Storage → public URL. Path: `{userId}/{itemId}/{filename}`.
+- **Photos:** Compress client-side → upload to the **private** `photos` bucket with `upsert: true` → serve via 1-year signed URL (`createSignedUrl`). Path: `{userId}/{itemId}/{slot}.jpg`. The bucket needs INSERT **and** UPDATE RLS policies (upsert overwrites are Postgres UPDATEs — see migration `012`).
 - **Server proxy:** Dedicated endpoints only. No open proxy pattern.
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,7 +51,7 @@
 ## In Progress
 
 - [x] Unified movie landing page with inline TMDB search and quick-add
-- [ ] Movie social polish (toast, badges, search filtering — current branch)
+- [x] Movie social polish — detail-modal redesign, SERP friend ratings/snaps, IMDb/RT display + four rating filters (My / People / IMDb / Rotten Tomatoes), and a stats scope toggle (Mine / Circle / Individual) with agreements/disagreements
 
 ---
 
@@ -73,7 +73,7 @@
 
 ### Priority 3: Stats Engine
 - [ ] Generic stats service (query items by category + user + time range)
-- [ ] Ring-gated friend comparison (collective stats, non-competitive framing)
+- [ ] Ring-gated friend comparison (collective stats, non-competitive framing) — shipped for **movies** (circle compatibility, agreements/disagreements, Mine/Circle/Individual scope toggle); generalize to other categories
 - [ ] Per-category stats tabs (reusable component pattern)
 - [ ] Dashboard "Your 2026 so far" summary widget
 

--- a/client/src/services/socialMovieStats.js
+++ b/client/src/services/socialMovieStats.js
@@ -67,7 +67,7 @@ export async function computeSocialMovieStats(myMovies, contacts) {
  * One entry per (movie, friend) pair, so a movie several friends rated can
  * appear multiple times with different counterparts.
  */
-function computeAgreements(myMovies, socialMovies, contacts) {
+export function computeAgreements(myMovies, socialMovies, contacts) {
   const whoByUid = {};
   contacts.forEach((c) => {
     const u = uid(c);

--- a/client/src/services/socialMovieStats.test.js
+++ b/client/src/services/socialMovieStats.test.js
@@ -1,0 +1,91 @@
+import { computeAgreements } from "./socialMovieStats";
+
+// Stub the network/data modules so importing the service doesn't boot the
+// Supabase client (computeAgreements is pure and uses none of them).
+// jest.mock is hoisted above the import, so the real modules never load.
+jest.mock("../features/movies/api/socialMovieApi", () => ({
+  getSocialMovies: jest.fn(),
+  computeTasteAlignment: jest.fn(),
+  getSuggestedMovies: jest.fn(),
+}));
+jest.mock("./recommendationService", () => ({
+  __esModule: true,
+  default: { getMySentRecommendations: jest.fn(), getMyRecommendations: jest.fn() },
+}));
+
+// computeAgreements splits movies both the user and a circle member rated into
+// agreements (ratings ≤1★ apart) and clashes (≥3★ apart), one entry per
+// (movie, friend) pair. Only the user's OWN watched+rated movies count as the
+// baseline; friends' ratings come from `_socialRating` (or `rating`).
+
+const contacts = [
+  { linkedUserId: "u-sarah", display_name: "Sarah", ring_level: 4 },
+  { linkedUserId: "u-mike", display_name: "Mike", ring_level: 2 },
+];
+
+function mine(tmdbId, rating, extra = {}) {
+  return { tmdbId, rating: String(rating), status: "watched", title: `Movie ${tmdbId}`, ...extra };
+}
+function theirs(tmdbId, uid, socialRating) {
+  return { tmdbId, _sharedByUserId: uid, _socialRating: socialRating };
+}
+
+test("classifies close ratings as agreements and far ratings as clashes", () => {
+  const myMovies = [mine("1", 5), mine("2", 5)];
+  const socialMovies = [
+    theirs("1", "u-sarah", 4), // |5-4| = 1 → agree
+    theirs("2", "u-mike", 1), // |5-1| = 4 → clash
+  ];
+
+  const { agreed, disagreed } = computeAgreements(myMovies, socialMovies, contacts);
+
+  expect(agreed.map((a) => a.tmdbId)).toEqual(["1"]);
+  expect(agreed[0]).toMatchObject({ myRating: 5, theirRating: 4, contactName: "Sarah" });
+  expect(disagreed.map((a) => a.tmdbId)).toEqual(["2"]);
+  expect(disagreed[0]).toMatchObject({ myRating: 5, theirRating: 1, contactName: "Mike" });
+});
+
+test("a 2★ gap is neither an agreement nor a clash", () => {
+  const { agreed, disagreed } = computeAgreements(
+    [mine("1", 5)],
+    [theirs("1", "u-sarah", 3)], // |5-3| = 2
+    contacts
+  );
+  expect(agreed).toHaveLength(0);
+  expect(disagreed).toHaveLength(0);
+});
+
+test("ignores movies the user has not watched+rated, and unrated friend entries", () => {
+  const myMovies = [
+    mine("1", 4),
+    { tmdbId: "2", status: "watchlist", rating: "" }, // not watched/rated
+    { tmdbId: "3", status: "watched", rating: "0" }, // rated 0
+  ];
+  const socialMovies = [
+    theirs("1", "u-sarah", 0), // friend has no rating → skipped
+    theirs("2", "u-sarah", 5), // mine not eligible → skipped
+    theirs("3", "u-mike", 5), // mine rated 0 → skipped
+    theirs("9", "u-mike", 5), // I never logged it → skipped
+  ];
+  const { agreed, disagreed } = computeAgreements(myMovies, socialMovies, contacts);
+  expect(agreed).toHaveLength(0);
+  expect(disagreed).toHaveLength(0);
+});
+
+test("excludes the user's shared (collaborator) entries from the baseline", () => {
+  const myMovies = [{ ...mine("1", 5), _isShared: true }];
+  const { agreed, disagreed } = computeAgreements(myMovies, [theirs("1", "u-sarah", 5)], contacts);
+  expect(agreed).toHaveLength(0);
+  expect(disagreed).toHaveLength(0);
+});
+
+test("emits one entry per movie/friend pair and falls back to 'A friend'", () => {
+  const myMovies = [mine("1", 5)];
+  const socialMovies = [
+    theirs("1", "u-sarah", 5),
+    theirs("1", "u-unknown", 5), // not in contacts → "A friend"
+  ];
+  const { agreed } = computeAgreements(myMovies, socialMovies, contacts);
+  expect(agreed).toHaveLength(2);
+  expect(agreed.map((a) => a.contactName).sort()).toEqual(["A friend", "Sarah"]);
+});


### PR DESCRIPTION
## Summary

Doc + test cleanup following the merged movie work (#15, #16, #17).

- **`CLAUDE.md`** — corrects the now-stale Photos pattern: private `photos` bucket, `upsert: true`, 1-year signed URLs, `{slot}.jpg` path, and the INSERT+UPDATE RLS requirement (migration `012`).
- **`ROADMAP.md`** — marks **Movie social polish** shipped (detail-modal redesign, SERP friend ratings/snaps, IMDb/RT display + four rating filters, stats scope toggle + agreements/disagreements) and notes the Priority-3 ring-gated friend comparison is now delivered for movies.
- **`socialMovieStats.js`** — exports `computeAgreements` and adds `socialMovieStats.test.js` with 5 cases: agree (≤1★) vs clash (≥3★) split, the neutral 2★ gap, eligibility filtering (unwatched/unrated/shared baseline, unrated friend), and one-entry-per-(movie, friend) pairing with the "A friend" fallback.

## Verification
- `CI=true react-scripts test` → **24/24 pass** (5 new)
- `react-scripts build` → clean
- Docs-only otherwise; no runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)