### PR TITLE
feat: unified single-row dropdown filters

### DIFF
--- a/client/src/components/shared/CategoryListHeader.js
+++ b/client/src/components/shared/CategoryListHeader.js
@@ -1,15 +1,17 @@
 import React from "react";
 import { Button } from "react-bootstrap";
 import StatsStrip from "./StatsStrip";
-import StatusToggle from "./StatusToggle";
-import YearFilter from "./YearFilter";
-import GroupedDropdownFilter from "./GroupedDropdownFilter";
+import MultiPillFilter from "./MultiPillFilter";
 import SourceFilterPills from "./SourceFilterPills";
+import { getStatusLabel } from "../../helpers/filterUtils";
 
 /**
- * Shared header component for all category list pages.
- * Renders the standard stack: Title row, StatsStrip, StatusToggle, Tabs, Filters, SourceFilterPills.
- * Each section is optional and driven by props.
+ * Shared header for all category list pages. The data filters — Status
+ * (Wishlist/Visited), Year, and the category-specific dimensions — render as one
+ * row of dropdown pills (each shows its active value, or the dimension name when
+ * unset). Source (Mine/Shared) and the View toggle stay as their own controls.
+ *
+ * Order: Title · Stats · [extra content] · [Status · Year · …filterPills] · Tabs · Source
  */
 export default function CategoryListHeader({
   title,
@@ -19,43 +21,70 @@ export default function CategoryListHeader({
 
   // StatsStrip
   stats,
+  statsLink,
 
-  // StatusToggle
+  // Status pill (built from the category's status options)
   category,
   statusOptions,
   filterStatus,
   onStatusChange,
 
-  // YearFilter (optional — renders only when 2+ years exist)
+  // Year pill
   yearOptions,
   activeYear,
   onYearChange,
 
-  // Tabs (optional view toggle, e.g. List/Map, Snaps/Photos)
+  // Category-specific dropdown pills (MultiPillFilter descriptors)
+  filterPills,
+  filterColor,
+
+  // Non-filter content rendered above the filter row (e.g. KidsStats, social feed)
+  renderExtraFilters,
+
+  // Tabs (view toggle, e.g. List/Map, Snaps/Photos)
   tabs,
   activeTab,
   onTabChange,
   tabColor,
 
-  // Custom filter slot (rendered between tabs and GroupedDropdownFilter)
-  renderExtraFilters,
-
-  // GroupedDropdownFilter
-  filterGroups,
-  filterValue,
-  onFilterChange,
-  filterColor,
-
-  // StatsLink (optional — renders inside StatsStrip)
-  statsLink,
-
-  // SourceFilterPills (optional)
+  // SourceFilterPills
   sourceFilter,
   onSourceChange,
   avatarUrl,
   sharedCount,
   recommendedCount,
 }) {
+  // Assemble the unified filter row: Status, Year, then category dimensions.
+  const unifiedPills = [];
+
+  if (statusOptions && statusOptions.length > 1 && filterStatus !== undefined && onStatusChange) {
+    unifiedPills.push({
+      key: "__status",
+      label: "Status",
+      allLabel: "Any status",
+      value: filterStatus,
+      onChange: onStatusChange,
+      options: statusOptions
+        .filter((s) => s !== "all")
+        .map((s) => ({ value: s, label: getStatusLabel(category, s) })),
+    });
+  }
+
+  if (yearOptions && yearOptions.length >= 1 && onYearChange) {
+    unifiedPills.push({
+      key: "__year",
+      label: "Year",
+      allLabel: "Any year",
+      value: activeYear,
+      onChange: onYearChange,
+      options: yearOptions.map((y) => ({ value: String(y), label: String(y) })),
+    });
+  }
+
+  if (filterPills && filterPills.length > 0) {
+    unifiedPills.push(...filterPills);
+  }
+
   return (
     <>
       {/* Title row */}
@@ -78,36 +107,12 @@ export default function CategoryListHeader({
         <StatsStrip stats={stats} icon="📊" statsLink={statsLink} />
       )}
 
-      {/* StatusToggle */}
-      {statusOptions && (
-        <StatusToggle
-          category={category}
-          options={statusOptions}
-          value={filterStatus}
-          onChange={onStatusChange}
-        />
-      )}
-
-      {/* YearFilter (renders null unless 2+ years available) */}
-      {yearOptions && onYearChange && (
-        <YearFilter
-          years={yearOptions}
-          value={activeYear}
-          onChange={onYearChange}
-        />
-      )}
-
-      {/* Custom extra filters (e.g. Kids ChildFilter, MilestoneTypeFilter) */}
+      {/* Non-filter content (KidsStats, MovieSocialFeed, …) above the filter row */}
       {renderExtraFilters && renderExtraFilters()}
 
-      {/* GroupedDropdownFilter (category-specific pills) */}
-      {filterGroups && filterGroups.length > 0 && (
-        <GroupedDropdownFilter
-          groups={filterGroups}
-          value={filterValue}
-          onChange={onFilterChange}
-          color={filterColor || "var(--color-primary)"}
-        />
+      {/* Unified filter row: Status · Year · category dimensions */}
+      {unifiedPills.length > 0 && (
+        <MultiPillFilter pills={unifiedPills} color={filterColor || "var(--color-primary)"} />
       )}
 
       {/* Tabs (pill-style view toggle, e.g. List/Map, Snaps/Photos) */}

--- a/client/src/components/shared/MultiPillFilter.js
+++ b/client/src/components/shared/MultiPillFilter.js
@@ -60,6 +60,10 @@ export default function MultiPillFilter({ pills, color = "var(--color-primary)" 
         const accent = pill.color || color;
         const isActive = pill.value && pill.value !== "all";
         const resetLabel = pill.allLabel || `All ${pill.label.replace(/^[^\w]*/, "").trim()}`;
+        // When a value is chosen, the pill shows that value; otherwise it shows
+        // the dimension name. The caret signals it opens a dropdown either way.
+        const selectedOption = pill.options.find((o) => o.value === pill.value);
+        const pillText = isActive && selectedOption ? selectedOption.label : pill.label;
 
         return (
           <div
@@ -82,7 +86,8 @@ export default function MultiPillFilter({ pills, color = "var(--color-primary)" 
                 cursor: "pointer",
               }}
             >
-              {pill.label}
+              {pillText}
+              <span aria-hidden="true" style={{ marginLeft: "0.3rem", opacity: 0.7, fontSize: "0.7em" }}>▾</span>
             </button>
 
             {openKey === pill.key && (

--- a/client/src/features/activities/components/ActivityList.js
+++ b/client/src/features/activities/components/ActivityList.js
@@ -9,7 +9,7 @@ import SnapCaptureModal from "../../../components/shared/SnapCaptureModal";
 import EntryDetailPanel from "../../../components/shared/EntryDetailPanel";
 import TripLink from "../../../components/shared/TripLink";
 import CategoryListHeader from "../../../components/shared/CategoryListHeader";
-import { RATING_GROUP } from "../../../components/shared/GroupedDropdownFilter";
+import { RATING_PILL_OPTIONS, matchesRatingValue } from "../../../components/shared/GroupedDropdownFilter";
 import activitySchema, { ACTIVITY_TYPES } from "../activitySchema";
 import useCategory from "../../../hooks/useCategory";
 import useListFilters from "../../../hooks/useListFilters";
@@ -19,18 +19,15 @@ import {
   filterByStatus,
 } from "../../../helpers/filterUtils";
 
-// Single "Type" pill listing every activity sub-category (Movie-style filter UX).
-const ACTIVITY_TYPE_GROUP = {
-  key: "activityType",
-  label: "\u{1F3D4}️ Type",
-  options: Object.values(ACTIVITY_TYPES).flatMap((g) =>
-    g.options.map((opt) => ({ value: opt, label: opt }))
-  ),
-};
+// Every activity sub-category, flattened into one "Type" dropdown's options.
+const ACTIVITY_TYPE_OPTIONS = Object.values(ACTIVITY_TYPES).flatMap((g) =>
+  g.options.map((opt) => ({ value: opt, label: opt }))
+);
 
 function ActivityList() {
   const location = useLocation();
   const [activityTypeFilter, setActivityTypeFilter] = React.useState("all");
+  const [ratingFilter, setRatingFilter] = React.useState("all");
   const { profile } = useAppData();
 
   const {
@@ -58,20 +55,16 @@ function ActivityList() {
   const statusFiltered = filterByStatus(activities, filterStatus);
   const commonFiltered = lf.applyCommonFilters(statusFiltered);
   const filteredActivities = React.useMemo(() => {
-    if (activityTypeFilter === "all") return commonFiltered;
-    if (activityTypeFilter.startsWith("rating:")) {
-      const rVal = activityTypeFilter.split(":")[1];
-      return commonFiltered.filter((i) => {
-        const r = parseInt(i.rating, 10);
-        if (rVal === "unrated") return !r;
-        if (rVal === "5") return r === 5;
-        if (rVal === "4+") return r >= 4;
-        if (rVal === "3+") return r >= 3;
-        return true;
-      });
-    }
-    return commonFiltered.filter((i) => i.activityType === activityTypeFilter);
-  }, [commonFiltered, activityTypeFilter]);
+    let items = commonFiltered;
+    if (activityTypeFilter !== "all") items = items.filter((i) => i.activityType === activityTypeFilter);
+    if (ratingFilter !== "all") items = items.filter((i) => matchesRatingValue(i.rating, ratingFilter));
+    return items;
+  }, [commonFiltered, activityTypeFilter, ratingFilter]);
+
+  const activityPills = [
+    { key: "activityType", label: "\u{1F3D4}️ Type", value: activityTypeFilter, onChange: setActivityTypeFilter, options: ACTIVITY_TYPE_OPTIONS },
+    { key: "rating", label: "★ Rating", value: ratingFilter, onChange: setRatingFilter, options: RATING_PILL_OPTIONS },
+  ];
 
   const done = activities.filter((i) => i.status === "done");
 
@@ -102,9 +95,7 @@ function ActivityList() {
         yearOptions={lf.yearOptions}
         activeYear={lf.activeYear}
         onYearChange={lf.setActiveYear}
-        filterGroups={[ACTIVITY_TYPE_GROUP, RATING_GROUP]}
-        filterValue={activityTypeFilter}
-        onFilterChange={setActivityTypeFilter}
+        filterPills={activityPills}
         filterColor="var(--color-activities, #2EB67D)"
         sourceFilter={lf.sourceFilter}
         onSourceChange={lf.setSourceFilter}

--- a/client/src/features/cars/components/CarList.js
+++ b/client/src/features/cars/components/CarList.js
@@ -7,7 +7,7 @@ import SaveToast from "../../../components/shared/SaveToast";
 import SnapCaptureModal from "../../../components/shared/SnapCaptureModal";
 import EntryDetailPanel from "../../../components/shared/EntryDetailPanel";
 import CategoryListHeader from "../../../components/shared/CategoryListHeader";
-import { RATING_GROUP } from "../../../components/shared/GroupedDropdownFilter";
+import { RATING_PILL_OPTIONS, matchesRatingValue } from "../../../components/shared/GroupedDropdownFilter";
 import carSchema from "../../../features/cars/carSchema";
 import useCategory from "../../../hooks/useCategory";
 import useListFilters from "../../../hooks/useListFilters";
@@ -23,7 +23,7 @@ import {
 const CAR_DATE = (c) => c.startDate || (c.year ? `${c.year}-01-01` : c.createdAt);
 
 function CarList() {
-  const [carFilter, setCarFilter] = React.useState("all");
+  const [ratingFilter, setRatingFilter] = React.useState("all");
   const { profile } = useAppData();
   const {
     items: cars,
@@ -43,20 +43,13 @@ function CarList() {
   const commonFiltered = lf.applyCommonFilters(statusFiltered);
 
   const filteredCars = React.useMemo(() => {
-    if (carFilter === "all") return commonFiltered;
-    if (carFilter.startsWith("rating:")) {
-      const rVal = carFilter.split(":")[1];
-      return commonFiltered.filter((i) => {
-        const r = parseInt(i.rating, 10);
-        if (rVal === "unrated") return !r;
-        if (rVal === "5") return r === 5;
-        if (rVal === "4+") return r >= 4;
-        if (rVal === "3+") return r >= 3;
-        return true;
-      });
-    }
-    return commonFiltered;
-  }, [commonFiltered, carFilter]);
+    if (ratingFilter === "all") return commonFiltered;
+    return commonFiltered.filter((i) => matchesRatingValue(i.rating, ratingFilter));
+  }, [commonFiltered, ratingFilter]);
+
+  const carPills = [
+    { key: "rating", label: "★ Rating", value: ratingFilter, onChange: setRatingFilter, options: RATING_PILL_OPTIONS },
+  ];
 
   const sectionTitle = `Cars - ${getStatusLabel("cars", filterStatus)}`;
 
@@ -76,9 +69,7 @@ function CarList() {
         yearOptions={lf.yearOptions}
         activeYear={lf.activeYear}
         onYearChange={lf.setActiveYear}
-        filterGroups={[RATING_GROUP]}
-        filterValue={carFilter}
-        onFilterChange={setCarFilter}
+        filterPills={carPills}
         filterColor="var(--color-cars, #36C5F0)"
         sourceFilter={lf.sourceFilter}
         onSourceChange={lf.setSourceFilter}

--- a/client/src/features/cellar/components/CellarList.js
+++ b/client/src/features/cellar/components/CellarList.js
@@ -7,7 +7,6 @@ import SaveToast from "../../../components/shared/SaveToast";
 import SnapCaptureModal from "../../../components/shared/SnapCaptureModal";
 import EntryDetailPanel from "../../../components/shared/EntryDetailPanel";
 import CategoryListHeader from "../../../components/shared/CategoryListHeader";
-import MultiPillFilter from "../../../components/shared/MultiPillFilter";
 import { RATING_PILL_OPTIONS, matchesRatingValue } from "../../../components/shared/GroupedDropdownFilter";
 import cellarSchema, { WINE_TYPES, WHISKEY_TYPES } from "../cellarSchema";
 import useCategory from "../../../hooks/useCategory";
@@ -166,9 +165,8 @@ function CellarList() {
         yearOptions={lf.yearOptions}
         activeYear={lf.activeYear}
         onYearChange={lf.setActiveYear}
-        renderExtraFilters={() => (
-          <MultiPillFilter pills={cellarPills} color="var(--color-cellar, #8B3A8F)" />
-        )}
+        filterPills={cellarPills}
+        filterColor="var(--color-cellar, #8B3A8F)"
         sourceFilter={lf.sourceFilter}
         onSourceChange={lf.setSourceFilter}
         avatarUrl={profile?.avatar_url}

--- a/client/src/features/events/components/EventList.js
+++ b/client/src/features/events/components/EventList.js
@@ -8,7 +8,7 @@ import SaveToast from "../../../components/shared/SaveToast";
 import SnapCaptureModal from "../../../components/shared/SnapCaptureModal";
 import EntryDetailPanel from "../../../components/shared/EntryDetailPanel";
 import CategoryListHeader from "../../../components/shared/CategoryListHeader";
-import { RATING_GROUP } from "../../../components/shared/GroupedDropdownFilter";
+import { RATING_PILL_OPTIONS, matchesRatingValue } from "../../../components/shared/GroupedDropdownFilter";
 import useCategory from "../../../hooks/useCategory";
 import useListFilters from "../../../hooks/useListFilters";
 import { useAppData } from "../../../contexts/AppDataContext";
@@ -48,6 +48,7 @@ function normalizeEvent(data) {
 
 function EventList() {
   const [filterType, setFilterType] = useState("all");
+  const [ratingFilter, setRatingFilter] = useState("all");
   const { profile } = useAppData();
   const {
     items: events,
@@ -99,34 +100,27 @@ function EventList() {
   const commonFiltered = lf.applyCommonFilters(statusFiltered);
 
   const filteredEvents = useMemo(() => {
-    if (filterType === "all") return commonFiltered;
-    if (filterType.startsWith("rating:")) {
-      const rVal = filterType.split(":")[1];
-      return commonFiltered.filter((i) => {
-        const r = parseInt(i.rating, 10);
-        if (rVal === "unrated") return !r;
-        if (rVal === "5") return r === 5;
-        if (rVal === "4+") return r >= 4;
-        if (rVal === "3+") return r >= 3;
-        return true;
-      });
-    }
-    return commonFiltered.filter((i) => i.eventType === filterType);
-  }, [commonFiltered, filterType]);
+    let items = commonFiltered;
+    if (filterType !== "all") items = items.filter((i) => i.eventType === filterType);
+    if (ratingFilter !== "all") items = items.filter((i) => matchesRatingValue(i.rating, ratingFilter));
+    return items;
+  }, [commonFiltered, filterType, ratingFilter]);
 
   const sectionTitle = `Events - ${getStatusLabel("events", filterStatus)}`;
 
-  const eventFilterGroups = useMemo(() => [
+  const eventPills = [
     {
       key: "type",
       label: "🎟️ Type",
+      value: filterType,
+      onChange: setFilterType,
       options: EVENT_TYPES.map((t) => ({
         value: t.value,
         label: `${EVENT_TYPE_EMOJIS[t.value] || "📌"} ${t.label}`,
       })),
     },
-    RATING_GROUP,
-  ], []);
+    { key: "rating", label: "★ Rating", value: ratingFilter, onChange: setRatingFilter, options: RATING_PILL_OPTIONS },
+  ];
 
   const getEventDisplayType = (item) => {
     return typeLabels[item.eventType] || "Event";
@@ -160,9 +154,7 @@ function EventList() {
         yearOptions={lf.yearOptions}
         activeYear={lf.activeYear}
         onYearChange={lf.setActiveYear}
-        filterGroups={eventFilterGroups}
-        filterValue={filterType}
-        onFilterChange={setFilterType}
+        filterPills={eventPills}
         filterColor="var(--color-events)"
         sourceFilter={lf.sourceFilter}
         onSourceChange={lf.setSourceFilter}

--- a/client/src/features/homes/components/HomeList.js
+++ b/client/src/features/homes/components/HomeList.js
@@ -7,7 +7,7 @@ import SaveToast from "../../../components/shared/SaveToast";
 import SnapCaptureModal from "../../../components/shared/SnapCaptureModal";
 import EntryDetailPanel from "../../../components/shared/EntryDetailPanel";
 import CategoryListHeader from "../../../components/shared/CategoryListHeader";
-import { RATING_GROUP } from "../../../components/shared/GroupedDropdownFilter";
+import { RATING_PILL_OPTIONS, matchesRatingValue } from "../../../components/shared/GroupedDropdownFilter";
 import homeSchema from "../../../features/homes/homeSchema";
 import useCategory from "../../../hooks/useCategory";
 import useListFilters from "../../../hooks/useListFilters";
@@ -23,7 +23,7 @@ import {
 const HOME_DATE_FIELDS = ["purchaseDate", "soldDate", "createdAt"];
 
 function HomeList() {
-  const [homeFilter, setHomeFilter] = React.useState("all");
+  const [ratingFilter, setRatingFilter] = React.useState("all");
   const { profile } = useAppData();
   const {
     items: homes,
@@ -43,20 +43,13 @@ function HomeList() {
   const commonFiltered = lf.applyCommonFilters(statusFiltered);
 
   const filteredHomes = React.useMemo(() => {
-    if (homeFilter === "all") return commonFiltered;
-    if (homeFilter.startsWith("rating:")) {
-      const rVal = homeFilter.split(":")[1];
-      return commonFiltered.filter((i) => {
-        const r = parseInt(i.rating, 10);
-        if (rVal === "unrated") return !r;
-        if (rVal === "5") return r === 5;
-        if (rVal === "4+") return r >= 4;
-        if (rVal === "3+") return r >= 3;
-        return true;
-      });
-    }
-    return commonFiltered;
-  }, [commonFiltered, homeFilter]);
+    if (ratingFilter === "all") return commonFiltered;
+    return commonFiltered.filter((i) => matchesRatingValue(i.rating, ratingFilter));
+  }, [commonFiltered, ratingFilter]);
+
+  const homePills = [
+    { key: "rating", label: "★ Rating", value: ratingFilter, onChange: setRatingFilter, options: RATING_PILL_OPTIONS },
+  ];
 
   const sectionTitle = `Homes - ${getStatusLabel("homes", filterStatus)}`;
 
@@ -76,9 +69,7 @@ function HomeList() {
         yearOptions={lf.yearOptions}
         activeYear={lf.activeYear}
         onYearChange={lf.setActiveYear}
-        filterGroups={[RATING_GROUP]}
-        filterValue={homeFilter}
-        onFilterChange={setHomeFilter}
+        filterPills={homePills}
         filterColor="var(--color-homes, #2EB67D)"
         sourceFilter={lf.sourceFilter}
         onSourceChange={lf.setSourceFilter}

--- a/client/src/features/kids/components/KidsList.js
+++ b/client/src/features/kids/components/KidsList.js
@@ -7,7 +7,6 @@ import SaveToast from "../../../components/shared/SaveToast";
 import SnapCaptureModal from "../../../components/shared/SnapCaptureModal";
 import EntryDetailPanel from "../../../components/shared/EntryDetailPanel";
 import CategoryListHeader from "../../../components/shared/CategoryListHeader";
-import MultiPillFilter from "../../../components/shared/MultiPillFilter";
 import { RATING_PILL_OPTIONS, matchesRatingValue } from "../../../components/shared/GroupedDropdownFilter";
 import kidsSchema, { KIDS_EVENT_TYPES } from "../kidsSchema";
 import useCategory from "../../../hooks/useCategory";
@@ -190,12 +189,9 @@ function KidsList() {
         yearOptions={lf.yearOptions}
         activeYear={lf.activeYear}
         onYearChange={lf.setActiveYear}
-        renderExtraFilters={() => (
-          <>
-            <KidsStats items={milestones} contacts={contacts} />
-            <MultiPillFilter pills={kidsPills} color="var(--color-kids, #FF6B35)" />
-          </>
-        )}
+        renderExtraFilters={() => <KidsStats items={milestones} contacts={contacts} />}
+        filterPills={kidsPills}
+        filterColor="var(--color-kids, #FF6B35)"
         sourceFilter={lf.sourceFilter}
         onSourceChange={lf.setSourceFilter}
         avatarUrl={profile?.avatar_url}

--- a/client/src/features/movies/components/MovieList.js
+++ b/client/src/features/movies/components/MovieList.js
@@ -110,9 +110,29 @@ function MovieList() {
     viewDetailItem, setViewDetailItem,
   } = useCategory("movies", { normalize: (data) => ({ ...data, status: data.status || "watchlist", startDate: data.startDate || "" }), schema: movieSchema });
 
-  const [movieFilter, setMovieFilter] = useState("all");
+  // Each movie filter dimension is independent so they combine (e.g. Drama +
+  // IMDb 8+ + RT 90+ at once). "all" = that dimension is unset.
+  const [genreFilter, setGenreFilter] = useState("all");
+  const [decadeFilter, setDecadeFilter] = useState("all");
+  const [myRatingFilter, setMyRatingFilter] = useState("all");
+  const [peopleRatingFilter, setPeopleRatingFilter] = useState("all");
+  const [imdbFilter, setImdbFilter] = useState("all");
+  const [rtFilter, setRtFilter] = useState("all");
+  const [ringFilter, setRingFilter] = useState("all");
   const lf = useListFilters(movies, { dateField: "startDate" });
   const { profile } = useAppData();
+
+  // Shared predicate so the library list and the search results filter identically.
+  const matchesRingFilter = useCallback((m, val) => {
+    if (val === "all") return true;
+    if (!m || !m._isShared) return val === "unwatched" ? !!(m && m._isRecommended && m.status !== "watched") : false;
+    const rr = parseInt(m.rating, 10);
+    if (val === "partner") return m._sharedByRing === 1 && rr >= 4;
+    if (val === "family") return (m._sharedByRing === 2 || m._sharedByRing === 3) && rr >= 4;
+    if (val === "friends") return m._sharedByRing === 4 && rr >= 4;
+    if (val === "unwatched") return m._isRecommended && m.status !== "watched";
+    return true;
+  }, []);
 
   // Inline TMDB search state
   const [searchQuery, setSearchQuery] = useState("");
@@ -312,36 +332,26 @@ function MovieList() {
         if (String(y) !== String(lf.activeYear)) return false;
       }
 
-      // Category dropdown (genre / decade / rating / imdb / rt / ring).
-      if (movieFilter !== "all") {
-        const [type, val] = movieFilter.split(":");
-        if (type === "genre") {
-          if (!(r.genre || "").split(",").map((g) => g.trim()).includes(val)) return false;
-        } else if (type === "decade") {
-          if (getDecade(r.year) !== val) return false;
-        } else if (type === "myrating") {
-          if (!matchesRating(lib?.rating, val)) return false;
-        } else if (type === "peoplerating") {
-          const pr = peopleRatingByTmdbId[r.tmdbId];
-          if (!(pr != null && pr >= parseFloat(val))) return false;
-        } else if (type === "imdb") {
-          const v = getImdb({ tmdbId: r.tmdbId, imdbRating: lib?.imdbRating });
-          if (!(v != null && v >= parseFloat(val))) return false;
-        } else if (type === "rt") {
-          const v = getRt({ tmdbId: r.tmdbId, rtRating: lib?.rtRating });
-          if (!(v != null && v >= parseFloat(val))) return false;
-        } else if (type === "ring") {
-          if (!lib || !lib._isShared) return false;
-          const rr = parseInt(lib.rating, 10);
-          if (val === "partner" && !(lib._sharedByRing === 1 && rr >= 4)) return false;
-          if (val === "family" && !((lib._sharedByRing === 2 || lib._sharedByRing === 3) && rr >= 4)) return false;
-          if (val === "friends" && !(lib._sharedByRing === 4 && rr >= 4)) return false;
-          if (val === "unwatched" && !(lib._isRecommended && lib.status !== "watched")) return false;
-        }
+      // Category dropdowns (each independent; they combine).
+      if (genreFilter !== "all" && !(r.genre || "").split(",").map((g) => g.trim()).includes(genreFilter)) return false;
+      if (decadeFilter !== "all" && getDecade(r.year) !== decadeFilter) return false;
+      if (myRatingFilter !== "all" && !matchesRating(lib?.rating, myRatingFilter)) return false;
+      if (peopleRatingFilter !== "all") {
+        const pr = peopleRatingByTmdbId[r.tmdbId];
+        if (!(pr != null && pr >= parseFloat(peopleRatingFilter))) return false;
       }
+      if (imdbFilter !== "all") {
+        const v = getImdb({ tmdbId: r.tmdbId, imdbRating: lib?.imdbRating });
+        if (!(v != null && v >= parseFloat(imdbFilter))) return false;
+      }
+      if (rtFilter !== "all") {
+        const v = getRt({ tmdbId: r.tmdbId, rtRating: lib?.rtRating });
+        if (!(v != null && v >= parseFloat(rtFilter))) return false;
+      }
+      if (ringFilter !== "all" && !matchesRingFilter(lib, ringFilter)) return false;
       return true;
     });
-  }, [searchResults, filterStatus, lf.sourceFilter, lf.activeYear, movieFilter, moviesByTmdbId, socialByTmdbId, peopleRatingByTmdbId, getImdb, getRt]);
+  }, [searchResults, filterStatus, lf.sourceFilter, lf.activeYear, genreFilter, decadeFilter, myRatingFilter, peopleRatingFilter, imdbFilter, rtFilter, ringFilter, matchesRingFilter, moviesByTmdbId, socialByTmdbId, peopleRatingByTmdbId, getImdb, getRt]);
 
   const movieStatuses = getStatusFilterOptions("movies");
 
@@ -367,120 +377,104 @@ function MovieList() {
     return DECADE_ORDER.filter((d) => present.has(d));
   }, [movies]);
 
-  const movieFilterGroups = useMemo(() => {
-    const groups = [];
+  const moviePills = useMemo(() => {
+    const pills = [];
     if (availableGenres.length > 0) {
-      groups.push({
+      pills.push({
         key: "genre",
         label: "\u{1F3AC} Genre",
-        options: availableGenres.map((g) => ({ value: `genre:${g}`, label: `${GENRE_EMOJIS[g] || "\u{1F3DE}️"} ${g}` })),
+        value: genreFilter,
+        onChange: setGenreFilter,
+        options: availableGenres.map((g) => ({ value: g, label: `${GENRE_EMOJIS[g] || "\u{1F3DE}️"} ${g}` })),
       });
     }
     if (availableDecades.length > 0) {
-      groups.push({
+      pills.push({
         key: "decade",
         label: "\u{1F4C5} Decade",
-        options: availableDecades.map((d) => ({ value: `decade:${d}`, label: d })),
+        value: decadeFilter,
+        onChange: setDecadeFilter,
+        options: availableDecades.map((d) => ({ value: d, label: d })),
       });
     }
-    groups.push({
+    pills.push({
       key: "myrating",
       label: "★ My Rating",
+      value: myRatingFilter,
+      onChange: setMyRatingFilter,
       options: [
-        { value: "myrating:5", label: "★★★★★" },
-        { value: "myrating:4+", label: "★★★★☆+" },
-        { value: "myrating:3+", label: "★★★☆☆+" },
-        { value: "myrating:unrated", label: "No rating" },
+        { value: "5", label: "★★★★★" },
+        { value: "4+", label: "★★★★☆+" },
+        { value: "3+", label: "★★★☆☆+" },
+        { value: "unrated", label: "No rating" },
       ],
     });
-    groups.push({
+    pills.push({
       key: "peoplerating",
-      label: "\u{1F465} My People Rating",
+      label: "\u{1F465} People Rating",
+      value: peopleRatingFilter,
+      onChange: setPeopleRatingFilter,
       options: [
-        { value: "peoplerating:4.5+", label: "★★★★★ Loved" },
-        { value: "peoplerating:4+", label: "★★★★☆+" },
-        { value: "peoplerating:3+", label: "★★★☆☆+" },
+        { value: "4.5+", label: "★★★★★ Loved" },
+        { value: "4+", label: "★★★★☆+" },
+        { value: "3+", label: "★★★☆☆+" },
       ],
     });
-    groups.push({
+    pills.push({
       key: "imdb",
-      label: "★ IMDb Rating",
+      label: "★ IMDb",
+      value: imdbFilter,
+      onChange: setImdbFilter,
       options: [
-        { value: "imdb:8+", label: "8+ Exceptional" },
-        { value: "imdb:7+", label: "7+ Great" },
-        { value: "imdb:6+", label: "6+ Good" },
+        { value: "8+", label: "8+ Exceptional" },
+        { value: "7+", label: "7+ Great" },
+        { value: "6+", label: "6+ Good" },
       ],
     });
-    groups.push({
+    pills.push({
       key: "rt",
       label: "\u{1F345} Rotten Tomatoes",
+      value: rtFilter,
+      onChange: setRtFilter,
       options: [
-        { value: "rt:90+", label: "90%+ Certified" },
-        { value: "rt:75+", label: "75%+ Fresh" },
-        { value: "rt:60+", label: "60%+" },
+        { value: "90+", label: "90%+ Certified" },
+        { value: "75+", label: "75%+ Fresh" },
+        { value: "60+", label: "60%+" },
       ],
     });
-    groups.push({
+    pills.push({
       key: "ring",
       label: "\u{1F48E} From Rings",
+      value: ringFilter,
+      onChange: setRingFilter,
       options: [
-        { value: "ring:partner", label: "\u{1F48E} Partner loved" },
-        { value: "ring:family", label: "\u{1F3E0} Family loved" },
-        { value: "ring:friends", label: "\u{1F465} Friends loved" },
-        { value: "ring:unwatched", label: "\u{1F3AF} Not yet watched (rec'd)" },
+        { value: "partner", label: "\u{1F48E} Partner loved" },
+        { value: "family", label: "\u{1F3E0} Family loved" },
+        { value: "friends", label: "\u{1F465} Friends loved" },
+        { value: "unwatched", label: "\u{1F3AF} Not yet watched (rec'd)" },
       ],
     });
-    return groups;
-  }, [availableGenres, availableDecades]);
+    return pills;
+  }, [availableGenres, availableDecades, genreFilter, decadeFilter, myRatingFilter, peopleRatingFilter, imdbFilter, rtFilter, ringFilter]);
 
   const statusFiltered = filterByStatus(movies, filterStatus);
   const commonFiltered = lf.applyCommonFilters(statusFiltered);
 
   const filteredMovies = useMemo(() => {
-    if (movieFilter === "all") return commonFiltered;
-    const [type, val] = movieFilter.split(":");
-    if (type === "genre") {
-      return commonFiltered.filter((m) =>
-        (m.genre || "").split(",").map((g) => g.trim()).includes(val)
-      );
-    }
-    if (type === "decade") {
-      return commonFiltered.filter((m) => getDecade(m.year) === val);
-    }
-    if (type === "myrating") {
-      return commonFiltered.filter((m) => matchesRating(m.rating, val));
-    }
-    if (type === "peoplerating") {
-      const min = parseFloat(val);
-      return commonFiltered.filter((m) => {
+    return commonFiltered.filter((m) => {
+      if (genreFilter !== "all" && !(m.genre || "").split(",").map((g) => g.trim()).includes(genreFilter)) return false;
+      if (decadeFilter !== "all" && getDecade(m.year) !== decadeFilter) return false;
+      if (myRatingFilter !== "all" && !matchesRating(m.rating, myRatingFilter)) return false;
+      if (peopleRatingFilter !== "all") {
         const pr = peopleRatingByTmdbId[m.tmdbId];
-        return pr != null && pr >= min;
-      });
-    }
-    if (type === "imdb") {
-      const min = parseFloat(val);
-      return commonFiltered.filter((m) => { const v = getImdb(m); return v != null && v >= min; });
-    }
-    if (type === "rt") {
-      const min = parseFloat(val);
-      return commonFiltered.filter((m) => { const v = getRt(m); return v != null && v >= min; });
-    }
-    if (type === "ring") {
-      if (val === "partner") {
-        return commonFiltered.filter((m) => m._isShared && m._sharedByRing === 1 && parseInt(m.rating, 10) >= 4);
+        if (!(pr != null && pr >= parseFloat(peopleRatingFilter))) return false;
       }
-      if (val === "family") {
-        return commonFiltered.filter((m) => m._isShared && (m._sharedByRing === 2 || m._sharedByRing === 3) && parseInt(m.rating, 10) >= 4);
-      }
-      if (val === "friends") {
-        return commonFiltered.filter((m) => m._isShared && m._sharedByRing === 4 && parseInt(m.rating, 10) >= 4);
-      }
-      if (val === "unwatched") {
-        return commonFiltered.filter((m) => m._isRecommended && m.status !== "watched");
-      }
-    }
-    return commonFiltered;
-  }, [commonFiltered, movieFilter, peopleRatingByTmdbId, getImdb, getRt]);
+      if (imdbFilter !== "all") { const v = getImdb(m); if (!(v != null && v >= parseFloat(imdbFilter))) return false; }
+      if (rtFilter !== "all") { const v = getRt(m); if (!(v != null && v >= parseFloat(rtFilter))) return false; }
+      if (ringFilter !== "all" && !matchesRingFilter(m, ringFilter)) return false;
+      return true;
+    });
+  }, [commonFiltered, genreFilter, decadeFilter, myRatingFilter, peopleRatingFilter, imdbFilter, rtFilter, ringFilter, matchesRingFilter, peopleRatingByTmdbId, getImdb, getRt]);
 
   const sectionTitle = `Movies - ${getStatusLabel("movies", filterStatus)}`;
   const watchedCount = movies.filter((m) => m.status === "watched").length;
@@ -551,9 +545,7 @@ function MovieList() {
         activeYear={lf.activeYear}
         onYearChange={lf.setActiveYear}
         renderExtraFilters={() => <MovieSocialFeed movies={movies} />}
-        filterGroups={movieFilterGroups}
-        filterValue={movieFilter}
-        onFilterChange={setMovieFilter}
+        filterPills={moviePills}
         filterColor="var(--color-movies, #E91E63)"
         sourceFilter={lf.sourceFilter}
         onSourceChange={lf.setSourceFilter}


### PR DESCRIPTION
## Summary
Collapses **Status (Wishlist/Visited)**, **Year**, and the **category-specific filters** into one row of dropdown pills. Each pill shows its active selection (or the dimension name when unset) with a ▾ caret, and selections **combine**.

The **Source** segment (Mine/Shared, with avatar) and **View** toggle (List/Map, Snaps/Photos) intentionally stay as their own distinct controls — they're identity/layout controls, not data filters.

```
Idle:    [ Status ▾ ] [ Year ▾ ] [ Genre ▾ ] [ Rating ▾ ]
Active:  [ Visited ▾ ] [ 2024 ▾ ] [ Genre ▾ ] [ 4★+ ▾ ]
```

## Changes
- **MultiPillFilter** — pill text reflects the chosen option when active, the dimension noun when idle; adds the caret.
- **CategoryListHeader** — builds Status + Year pills, prepends them to each page's `filterPills`, renders one `MultiPillFilter`; drops the separate StatusToggle / YearFilter / GroupedDropdownFilter rows.
- **All category pages → combinable independent pills:** Cars/Homes (Rating), Activities (Type + Rating), Events (Type + Rating), Cellar/Kids (moved onto the unified row), and **Movies** (Genre, Decade, My/People/IMDb/RT ratings, Rings — now combinable, applied to both the library list and TMDB search results).

## Verification
- ✅ `npx react-scripts build` clean
- ✅ 130/130 tests pass
- ✅ `node` logic checks: combinable movie filtering, ring predicate, and the pill active-label behavior all pass
- ⚠️ Authenticated UI spot-check is yours (login-gated): confirm the one-row pills, that combining works (e.g. Drama + IMDb 8+), and that the active pill shows the selected value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)