### PR TITLE
feat: unified dropdown-pill filter row on Timeline, Memories, Shared, Recs

### DIFF
--- a/client/src/pages/Recommendations.js
+++ b/client/src/pages/Recommendations.js
@@ -8,8 +8,7 @@ import dataService from "../services/dataService";
 import { getCategoryMeta } from "../helpers/categoryMeta";
 import statusLabels from "../helpers/statusLabels";
 import { findMatchingOwnedItem, mergeRecommender } from "../helpers/recommendationMatcher";
-import YearFilter from "../components/shared/YearFilter";
-import GroupedDropdownFilter from "../components/shared/GroupedDropdownFilter";
+import MultiPillFilter from "../components/shared/MultiPillFilter";
 import { getYearOptions, filterByYear } from "../helpers/filterUtils";
 
 // Year/category derive from the recommended entry's date (falling back to when
@@ -160,20 +159,34 @@ function Recommendations() {
     : enriched.filter((r) => r.status === TAB_TO_STATUS[statusFilter]);
 
   const categories = [...new Set(enriched.map((r) => r.category))];
-  const categoryFilterGroups = [{
-    key: "category",
-    label: "\u{1F4C2} Category",
-    options: categories.map((cat) => ({
-      value: cat,
-      label: `${getCategoryMeta(cat).icon} ${cat.charAt(0).toUpperCase() + cat.slice(1)}`,
-    })),
-  }];
   const yearOptions = getYearOptions(enriched, recDate);
 
   const categoryFiltered = categoryFilter === "all"
     ? statusFiltered
     : statusFiltered.filter((r) => r.category === categoryFilter);
   const filtered = filterByYear(categoryFiltered, activeYear, recDate);
+
+  // One dropdown-pill row: Status · Year · Category — consistent with the rest.
+  const recPills = [
+    {
+      key: "__status", label: "Status", allLabel: "Any status",
+      value: statusFilter, onChange: setStatusFilter,
+      options: STATUS_TABS.filter((s) => s !== "all").map((s) => ({ value: s, label: s.charAt(0).toUpperCase() + s.slice(1) })),
+    },
+    ...(yearOptions.length > 0 ? [{
+      key: "__year", label: "Year", allLabel: "Any year",
+      value: activeYear, onChange: setActiveYear,
+      options: yearOptions.map((y) => ({ value: String(y), label: String(y) })),
+    }] : []),
+    ...(categories.length >= 1 ? [{
+      key: "category", label: "\u{1F4C2} Category", allLabel: "All categories",
+      value: categoryFilter, onChange: setCategoryFilter,
+      options: categories.map((cat) => ({
+        value: cat,
+        label: `${getCategoryMeta(cat).icon} ${cat.charAt(0).toUpperCase() + cat.slice(1)}`,
+      })),
+    }] : []),
+  ];
 
   if (loading) {
     return (
@@ -194,39 +207,8 @@ function Recommendations() {
         )}
       </div>
 
-      {/* Status filter — mirrors the Shared Experiences feed */}
-      <div style={{ display: "flex", gap: "0.75rem", marginBottom: "1rem", flexWrap: "wrap" }}>
-        <div>
-          <div style={{ fontSize: "var(--font-size-xs)", fontWeight: 700, color: "var(--color-text-tertiary)", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: "0.25rem" }}>Status</div>
-          <div className="status-toggle">
-            {STATUS_TABS.map((s) => (
-              <button
-                key={s}
-                type="button"
-                className={`btn btn-sm ${statusFilter === s ? "active" : ""}`}
-                data-status={s === "all" ? undefined : s}
-                onClick={() => setStatusFilter(s)}
-                style={{ textTransform: "capitalize" }}
-              >
-                {s === "all" ? "All" : s.charAt(0).toUpperCase() + s.slice(1)}
-              </button>
-            ))}
-          </div>
-        </div>
-      </div>
-
-      {/* Year filter (renders only when 2+ years exist) */}
-      <YearFilter years={yearOptions} value={activeYear} onChange={setActiveYear} />
-
-      {/* Category filter — single pill, matching the category pages */}
-      {categories.length >= 1 && (
-        <GroupedDropdownFilter
-          groups={categoryFilterGroups}
-          value={categoryFilter}
-          onChange={setCategoryFilter}
-          color="var(--color-primary)"
-        />
-      )}
+      {/* Unified filter row: Status · Year · Category */}
+      <MultiPillFilter pills={recPills} color="var(--color-primary)" />
 
       {filtered.length === 0 ? (
         <div className="empty-state">

--- a/client/src/pages/SharedFeed.js
+++ b/client/src/pages/SharedFeed.js
@@ -9,8 +9,7 @@ import { useSocialData } from "../contexts/SocialDataContext";
 import categoryMeta, { getEntryTitle, getEntrySubtitle, getCategoryMeta } from "../helpers/categoryMeta";
 import { formatDateRange } from "../helpers/dateUtils";
 import StarRating from "../components/shared/StarRating";
-import YearFilter from "../components/shared/YearFilter";
-import GroupedDropdownFilter from "../components/shared/GroupedDropdownFilter";
+import MultiPillFilter from "../components/shared/MultiPillFilter";
 import { getYearOptions, filterByYear } from "../helpers/filterUtils";
 
 // ── Shared Entry Card ─────────────────────────────────────────────────────────
@@ -375,15 +374,33 @@ function SharedFeed() {
       }));
 
   const categories = [...new Set(sharedEntries.map((e) => e._category).filter(Boolean))];
-  const categoryFilterGroups = [{
-    key: "category",
-    label: "\u{1F4C2} Category",
-    options: categories.map((cat) => ({
-      value: cat,
-      label: `${getCategoryMeta(cat).icon} ${cat.charAt(0).toUpperCase() + cat.slice(1)}`,
-    })),
-  }];
   const yearOptions = getYearOptions(sharedEntries, ["startDate", "createdAt"]);
+
+  // One dropdown-pill row: Status · Year · Category — consistent with the rest.
+  const sharedPills = [
+    {
+      key: "__status", label: "Status", allLabel: "Any status",
+      value: filterStatus, onChange: setFilterStatus,
+      options: [
+        { value: "pending", label: "Pending" },
+        { value: "accepted", label: "Accepted" },
+        { value: "declined", label: "Declined" },
+      ],
+    },
+    ...(yearOptions.length > 0 ? [{
+      key: "__year", label: "Year", allLabel: "Any year",
+      value: activeYear, onChange: setActiveYear,
+      options: yearOptions.map((y) => ({ value: String(y), label: String(y) })),
+    }] : []),
+    ...(categories.length >= 1 ? [{
+      key: "category", label: "\u{1F4C2} Category", allLabel: "All categories",
+      value: categoryFilter, onChange: setCategoryFilter,
+      options: categories.map((cat) => ({
+        value: cat,
+        label: `${getCategoryMeta(cat).icon} ${cat.charAt(0).toUpperCase() + cat.slice(1)}`,
+      })),
+    }] : []),
+  ];
 
   const filteredEntries = filterByYear(
     sharedEntries.filter((item) => {
@@ -474,39 +491,8 @@ function SharedFeed() {
         Entries shared with you by others appear here. Accept to add them to your timeline and contribute your own Snapshots.
       </div>
 
-      {/* Filters */}
-      <div style={{ display: "flex", gap: "0.75rem", marginBottom: "1.25rem", flexWrap: "wrap" }}>
-        <div>
-          <div style={{ fontSize: "var(--font-size-xs)", fontWeight: 700, color: "var(--color-text-tertiary)", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: "0.25rem" }}>Status</div>
-          <div className="status-toggle">
-            {["all", "pending", "accepted", "declined"].map((s) => (
-              <button
-                key={s}
-                type="button"
-                className={`btn btn-sm ${filterStatus === s ? "active" : ""}`}
-                data-status={s === "all" ? undefined : s}
-                onClick={() => setFilterStatus(s)}
-                style={{ textTransform: "capitalize" }}
-              >
-                {s === "all" ? "All" : s.charAt(0).toUpperCase() + s.slice(1)}
-              </button>
-            ))}
-          </div>
-        </div>
-      </div>
-
-      {/* Year filter (renders only when 2+ years exist) */}
-      <YearFilter years={yearOptions} value={activeYear} onChange={setActiveYear} />
-
-      {/* Category filter — single pill, matching the category pages */}
-      {categories.length >= 1 && (
-        <GroupedDropdownFilter
-          groups={categoryFilterGroups}
-          value={categoryFilter}
-          onChange={setCategoryFilter}
-          color="var(--color-primary)"
-        />
-      )}
+      {/* Unified filter row: Status · Year · Category */}
+      <MultiPillFilter pills={sharedPills} color="var(--color-primary)" />
 
       {loading ? (
         <div style={{ textAlign: "center", padding: "3rem", color: "var(--color-text-tertiary)" }}>Loading…</div>

--- a/client/src/pages/Snaps.js
+++ b/client/src/pages/Snaps.js
@@ -11,8 +11,8 @@ import {
 import dataService from "../services/dataService";
 import SourceFilterPills from "../components/shared/SourceFilterPills";
 import StatsStrip from "../components/shared/StatsStrip";
-import YearFilter from "../components/shared/YearFilter";
-import DoneWishlistFilter, { matchesDoneWishlist } from "../components/shared/DoneWishlistFilter";
+import MultiPillFilter from "../components/shared/MultiPillFilter";
+import { matchesDoneWishlist } from "../components/shared/DoneWishlistFilter";
 import { getYearOptions, filterByYear } from "../helpers/filterUtils";
 import EntryDetailPanel from "../components/shared/EntryDetailPanel";
 import { useAppData } from "../contexts/AppDataContext";
@@ -191,6 +191,28 @@ function Snaps() {
     return hasSnap || hasPhoto;
   });
 
+  // One dropdown-pill row: Status · Year · Category (view toggle stays separate).
+  const snapsPills = [
+    {
+      key: "__status", label: "Status", allLabel: "Any status",
+      value: activeStatus, onChange: setActiveStatus,
+      options: [{ value: "done", label: "Done" }, { value: "wishlist", label: "Wishlist" }],
+    },
+    ...(yearOptions.length > 0 ? [{
+      key: "__year", label: "Year", allLabel: "Any year",
+      value: activeYear, onChange: setActiveYear,
+      options: yearOptions.map((y) => ({ value: String(y), label: String(y) })),
+    }] : []),
+    ...(categoriesWithContent.length > 1 ? [{
+      key: "__category", label: "Category", allLabel: "All categories",
+      value: activeCategory, onChange: setActiveCategory,
+      options: categoriesWithContent.map((cat) => ({
+        value: cat.key,
+        label: `${(categoryMeta[cat.key] || {}).icon || ""} ${cat.label}`,
+      })),
+    }] : []),
+  ];
+
   if (loading) return null;
 
   const totalSnaps = allSnaps.length;
@@ -210,35 +232,8 @@ function Snaps() {
         ]} />
       )}
 
-      {/* Done / Wishlist status */}
-      <DoneWishlistFilter value={activeStatus} onChange={setActiveStatus} />
-
-      {/* Year filter (renders whenever any dated items exist) */}
-      <YearFilter years={yearOptions} value={activeYear} onChange={setActiveYear} />
-
-      {/* Category filter pills */}
-      {categoriesWithContent.length > 1 && (
-        <div className="status-toggle mb-3">
-          <button
-            className={`btn ${activeCategory === "all" ? "active" : ""}`}
-            onClick={() => setActiveCategory("all")}
-          >
-            All
-          </button>
-          {categoriesWithContent.map((cat) => {
-            const meta = categoryMeta[cat.key] || {};
-            return (
-              <button
-                key={cat.key}
-                className={`btn ${activeCategory === cat.key ? "active" : ""}`}
-                onClick={() => setActiveCategory(cat.key)}
-              >
-                {meta.icon} {cat.label}
-              </button>
-            );
-          })}
-        </div>
-      )}
+      {/* Unified filter row: Status · Year · Category */}
+      <MultiPillFilter pills={snapsPills} color="var(--color-primary)" />
 
       {/* View tabs: All / Snaps / Photos */}
       <div className="d-flex gap-2 mb-3">

--- a/client/src/pages/Timeline.js
+++ b/client/src/pages/Timeline.js
@@ -9,8 +9,8 @@ import PrivacyIndicator from "../components/shared/PrivacyIndicator";
 import SourceFilterPills from "../components/shared/SourceFilterPills";
 import EntryDetailPanel from "../components/shared/EntryDetailPanel";
 import StatsStrip from "../components/shared/StatsStrip";
-import YearFilter from "../components/shared/YearFilter";
-import DoneWishlistFilter, { matchesDoneWishlist } from "../components/shared/DoneWishlistFilter";
+import MultiPillFilter from "../components/shared/MultiPillFilter";
+import { matchesDoneWishlist } from "../components/shared/DoneWishlistFilter";
 import { useAppData } from "../contexts/AppDataContext";
 import { SCHEMA_MAP, CATEGORY_KEYS } from "../helpers/schemaRegistry";
 import { enrichItemsWithSocialContent, getSocialPreview } from "../helpers/socialContent";
@@ -159,6 +159,34 @@ function Timeline() {
 
   const groupedMonths = Object.keys(grouped);
 
+  // One dropdown-pill row: Status · Year · Month (when a year is picked) · Category.
+  const timelinePills = [
+    {
+      key: "__status", label: "Status", allLabel: "Any status",
+      value: activeStatus, onChange: setActiveStatus,
+      options: [{ value: "done", label: "Done" }, { value: "wishlist", label: "Wishlist" }],
+    },
+    ...(years.length > 0 ? [{
+      key: "__year", label: "Year", allLabel: "Any year",
+      value: activeYear, onChange: (y) => { setActiveYear(y); setActiveMonth("all"); },
+      options: years.map((y) => ({ value: String(y), label: String(y) })),
+    }] : []),
+    ...(monthsWithData.length > 0 ? [{
+      key: "__month", label: "Month", allLabel: "All months",
+      value: activeMonth, onChange: setActiveMonth,
+      options: monthsWithData.map((m) => ({ value: String(m), label: MONTH_NAMES[m] })),
+      visibleWhen: (v) => v.__year && v.__year !== "all",
+    }] : []),
+    ...(timelineCategories.length > 1 ? [{
+      key: "__category", label: "Category", allLabel: "All categories",
+      value: activeCategory, onChange: setActiveCategory,
+      options: timelineCategories.map((cat) => ({
+        value: cat,
+        label: `${(categoryMeta[cat] || {}).icon || ""} ${cat.charAt(0).toUpperCase() + cat.slice(1)}`,
+      })),
+    }] : []),
+  ];
+
   if (loading) return null;
 
   return (
@@ -184,60 +212,8 @@ function Timeline() {
         return <StatsStrip stats={stats} />;
       })()}
 
-      {/* Done / Wishlist status */}
-      <DoneWishlistFilter value={activeStatus} onChange={setActiveStatus} />
-
-      {/* Year filter (shared component; renders whenever any dated items exist) */}
-      <YearFilter
-        years={years}
-        value={activeYear}
-        onChange={(y) => { setActiveYear(y); setActiveMonth("all"); }}
-      />
-
-      {/* Month sub-pills (only when a year is selected) */}
-      {activeYear !== "all" && monthsWithData.length > 0 && (
-        <div className="status-toggle mb-2" style={{ fontSize: "var(--font-size-xs)" }}>
-          <button
-            className={`btn ${activeMonth === "all" ? "active" : ""}`}
-            onClick={() => setActiveMonth("all")}
-          >
-            All Months
-          </button>
-          {monthsWithData.map((m) => (
-            <button
-              key={m}
-              className={`btn ${activeMonth === String(m) ? "active" : ""}`}
-              onClick={() => setActiveMonth(String(m))}
-            >
-              {MONTH_NAMES[m]}
-            </button>
-          ))}
-        </div>
-      )}
-
-      {/* Category filter */}
-      {timelineCategories.length > 1 && (
-        <div className="status-toggle mb-2">
-          <button
-            className={`btn ${activeCategory === "all" ? "active" : ""}`}
-            onClick={() => setActiveCategory("all")}
-          >
-            All
-          </button>
-          {timelineCategories.map((cat) => {
-            const meta = categoryMeta[cat] || {};
-            return (
-              <button
-                key={cat}
-                className={`btn ${activeCategory === cat ? "active" : ""}`}
-                onClick={() => setActiveCategory(cat)}
-              >
-                {meta.icon} {cat.charAt(0).toUpperCase() + cat.slice(1)}
-              </button>
-            );
-          })}
-        </div>
-      )}
+      {/* Unified filter row: Status · Year · Month · Category */}
+      <MultiPillFilter pills={timelinePills} color="var(--color-primary)" />
 
       {/* Source filter (All / Mine / Shared / Recommended) */}
       <SourceFilterPills


### PR DESCRIPTION
Brings the four aggregate pages onto the same condensed `MultiPillFilter` UX as the category pages — one row of dropdown pills, each showing its active value (or the dimension name when unset) with a ▾ caret.

- **Timeline** — Status (Done/Wishlist) · Year · Month (appears once a year is picked, via `visibleWhen`) · Category, replacing the stacked toggle/year/month/category rows. Source segment stays separate.
- **My Memories** — Status · Year · Category as pills; the Snaps/Photos view tabs and Source segment stay as their own controls.
- **Recommendations** & **Shared Experiences** — Status (Pending/Accepted/Declined) · Year · Category as one pill row, replacing the labeled status toggle + YearFilter + GroupedDropdownFilter.

Net −61 lines. Build clean. Consistent with the category-page unified row already on main.

⚠️ Login-gated, so verify in the browser after merge: the one-row pills on all four pages, and that an active pill shows the selected value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)